### PR TITLE
DBO+aclgrph 

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -624,7 +624,7 @@ def unified_attention(
     forward_context: ForwardContext = get_forward_context()
     attn_metadata = forward_context.attn_metadata
     if afd_metadata is not None and isinstance(attn_metadata, list):
-        afd_stage_idx = afd_metadata.afd_stage_idx
+        afd_stage_idx = forward_context.ubatch_idx
         if afd_stage_idx < len(attn_metadata):
             attn_metadata = attn_metadata[afd_stage_idx]
         else:

--- a/vllm/distributed/afd_transfer/afd_connector/metadata.py
+++ b/vllm/distributed/afd_transfer/afd_connector/metadata.py
@@ -120,6 +120,7 @@ class AFDConnectorMetadata:
     # multiple sequences
     dtype: torch.dtype
     device: torch.device
+    num_ubatches: int = 1
     topk_idx: Optional[torch.Tensor] = None # indices token which expert to be sended
     topk_weights: Optional[torch.Tensor] = None # the expert weights
     moe_expert_num: Optional[int] = None # number of moe experts
@@ -177,6 +178,7 @@ class AFDConnectorMetadata:
             seq_len: int,
             dtype: torch.dtype,
             device: torch.device,
+            num_ubatches: int = 1,
             request_id: Optional[str] = None,
             ffn_need_forward_data:Optional[FFNNeedForwardData] = None,
             m2n_afdconnector_data:Optional[M2NAFDConnectorMetadata] = None,
@@ -192,6 +194,7 @@ class AFDConnectorMetadata:
                    seq_lens=[seq_len],
                    dtype=dtype,
                    device=device,
+                   num_ubatches=num_ubatches,
                    request_id=request_id,
                 #    timestamp=time.time(),
                    ffn_need_forward_data=ffn_need_forward_data,

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -332,6 +332,7 @@ class ForwardContext:
     ubatch_slices: Optional[UBatchSlices] = None
     ubatch_idx: int = 0
     num_ubatches: int = 1
+    cam_afdconnector_data: Optional[Any] = None
 
     def __post_init__(self):
         assert self.cudagraph_runtime_mode in [

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -332,6 +332,7 @@ class ForwardContext:
     ubatch_slices: Optional[UBatchSlices] = None
     ubatch_idx: int = 0
     num_ubatches: int = 1
+    # TODO(yxj):to support different afdconnector
     cam_afdconnector_data: Optional[Any] = None
 
     def __post_init__(self):

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -331,6 +331,7 @@ class ForwardContext:
 
     ubatch_slices: Optional[UBatchSlices] = None
     ubatch_idx: int = 0
+    num_ubatches: int = 1
 
     def __post_init__(self):
         assert self.cudagraph_runtime_mode in [

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -4,7 +4,7 @@
 import time
 from collections import defaultdict
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 import torch
@@ -330,6 +330,7 @@ class ForwardContext:
     batch_descriptor: Optional[BatchDescriptor] = None
 
     ubatch_slices: Optional[UBatchSlices] = None
+    ubatch_idx: int = 0
 
     def __post_init__(self):
         assert self.cudagraph_runtime_mode in [
@@ -356,7 +357,8 @@ def create_forward_context(
     cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
     batch_descriptor: BatchDescriptor | None = None,
     ubatch_slices: UBatchSlices | None = None,
-    afd_metadata: AFDMetadata | None = None
+    afd_metadata: AFDMetadata | None = None,
+    ubatch_idx: int = 0
 ):
     return ForwardContext(
         no_compile_layers=vllm_config.compilation_config.static_forward_context,
@@ -366,7 +368,8 @@ def create_forward_context(
         cudagraph_runtime_mode=cudagraph_runtime_mode,
         batch_descriptor=batch_descriptor,
         ubatch_slices=ubatch_slices,
-        afd_metadata=afd_metadata
+        afd_metadata=afd_metadata,
+        ubatch_idx=ubatch_idx
     )
 
 

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1019,7 +1019,7 @@ class DeepseekV2Model(nn.Module):
                                                                         ubatch_metadata[ubatch_idx],ubatch_idx)
                     # recv_hidden_states = afd_connector.recv_ffn_output(ubatch_hidden_states[ubatch_idx],
                     #                                                    ubatch_metadata[ubatch_idx],ubatch_idx)
-                elif self.connector_name == "camconnector":
+                elif self.connector_name == "camm2nconnector":
                     recv_hidden_states = afd_connector.recv_ffn_output(hidden_states,
                                                                         metadata,
                                                                         forward_ctx.ubatch_idx)
@@ -1049,7 +1049,7 @@ class DeepseekV2Model(nn.Module):
                     aiv_num = 48,
                     batch_size = self.max_num_reqs,
                     h = self.config.hidden_size,
-                    k = self.num_experts_per_tok
+                    k = self.config.num_experts_per_tok
                 )
             if self.connector_name == "camp2pconnector":
                 from vllm_ascend.distributed.CAMP2PAFDConnector import CAMP2PAFDConnectorMetadata
@@ -1062,7 +1062,7 @@ class DeepseekV2Model(nn.Module):
                     aiv_num = 48,
                     batch_size = self.max_num_reqs,
                     h = self.config.hidden_size,
-                    k = self.num_experts_per_tok
+                    k = self.config.num_experts_per_tok
                 )
 
             metadata = AFDConnectorMetadata.create_attention_metadata(
@@ -1109,7 +1109,7 @@ class DeepseekV2Model(nn.Module):
                                                                    ubatch_metadata[ubatch_idx],ubatch_idx)
                 # recv_hidden_states = afd_connector.recv_ffn_output(ubatch_hidden_states[ubatch_idx],
                 #                                                    ubatch_metadata[ubatch_idx],ubatch_idx)
-        elif self.connector_name == "camconnector":
+        elif self.connector_name == "camm2nconnector":
             recv_hidden_states = afd_connector.recv_ffn_output(hidden_states,
                                                                 metadata,
                                                                 forward_ctx.ubatch_idx)

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -995,10 +995,11 @@ class DeepseekV2Model(nn.Module):
             # Compute dense layers on attn side.
             if layer.layer_idx < self.first_k_dense_replace:
                 hidden_states, residual = layer(positions, hidden_states, residual)
+                # hidden_states = apply_dbo_yield(hidden_states)
                 continue
             
             afd_connector = afd_metadata.afd_connector
-            afd_metadata.afd_stage_idx = dbo_current_ubatch_id()
+            afd_metadata.afd_stage_idx = forward_ctx.ubatch_idx
             start_idx = afd_metadata.afd_tokens_start_loc[afd_metadata.afd_stage_idx]
             end_idx = start_idx + afd_metadata.afd_tokens_lens[afd_metadata.afd_stage_idx]
 
@@ -1012,6 +1013,22 @@ class DeepseekV2Model(nn.Module):
                 for work in recv_handle:
                     work.wait()
 
+            if layer.layer_idx > self.first_k_dense_replace:
+                if self.connector_name == "m2nconnector":
+                    recv_hidden_states = afd_connector.recv_ffn_output(ubatch_hidden_states[ubatch_idx],
+                                                                        ubatch_metadata[ubatch_idx],ubatch_idx)
+                    # recv_hidden_states = afd_connector.recv_ffn_output(ubatch_hidden_states[ubatch_idx],
+                    #                                                    ubatch_metadata[ubatch_idx],ubatch_idx)
+                elif self.connector_name == "camconnector":
+                    recv_hidden_states = afd_connector.recv_ffn_output(hidden_states,
+                                                                        metadata,
+                                                                        forward_ctx.ubatch_idx)
+                    
+                else:
+                    recv_hidden_states, _ = afd_connector.recv_ffn_output()
+                    
+                hidden_states = recv_hidden_states
+            
             current_hidden, residual, topk_weights, topk_ids, row_idx,router_logits= \
                 layer.compute_attn_output(positions, hidden_states, residual)
             if self.connector_name == "m2nconnector":
@@ -1065,7 +1082,7 @@ class DeepseekV2Model(nn.Module):
                 metadata.m2n_afdconnector_data.handle = handle
                 hidden_states = afd_connector.recv_ffn_output(hidden_states,metadata)
             elif self.connector_name == "camm2nconnector":
-                output_list = afd_connector.send_attn_output(current_hidden, topk_weights, topk_ids, metadata)
+                output_list = afd_connector.send_attn_output(current_hidden, topk_weights, topk_ids, metadata,forward_ctx.ubatch_idx)
                 hidden_states1, dynamic_scales, expandIdx, expertTokenNums, epRecvCounts, simulateExpertIds, simulateExpertScales, attenBatchSize = output_list[0:8]
                 handle = [simulateExpertIds, simulateExpertScales, expandIdx, epRecvCounts, attenBatchSize]
                 metadata.cam_m2n_afdconnector_data.handle = handle
@@ -1075,7 +1092,6 @@ class DeepseekV2Model(nn.Module):
                 hidden_states1, simulateExpertIds, simulateExpertScales, attenBatchSize, xActiveMaskOut = output_list[0:5]
                 handle = [hidden_states1, simulateExpertIds, simulateExpertScales, attenBatchSize]
                 metadata.cam_p2p_afdconnector_data.handle = handle
-                hidden_states = afd_connector.recv_ffn_output(hidden_states, metadata)
             else:
                 afd_connector.send_attn_output(hidden_states = current_hidden,
                                                router_logits = router_logits,
@@ -1090,6 +1106,20 @@ class DeepseekV2Model(nn.Module):
             # if dbo_enabled():
             #     dbo_yield()
             hidden_states = apply_dbo_yield(hidden_states)
+            
+        if self.connector_name == "m2nconnector":
+                recv_hidden_states = afd_connector.recv_ffn_output(ubatch_hidden_states[ubatch_idx],
+                                                                   ubatch_metadata[ubatch_idx],ubatch_idx)
+                # recv_hidden_states = afd_connector.recv_ffn_output(ubatch_hidden_states[ubatch_idx],
+                #                                                    ubatch_metadata[ubatch_idx],ubatch_idx)
+        elif self.connector_name == "camconnector":
+            recv_hidden_states = afd_connector.recv_ffn_output(hidden_states,
+                                                                metadata,
+                                                                forward_ctx.ubatch_idx)
+        else:
+            recv_hidden_states, _ = afd_connector.recv_ffn_output()
+        hidden_states = recv_hidden_states
+        
         return hidden_states, residual
 
     def forward(

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1098,17 +1098,11 @@ class DeepseekV2Model(nn.Module):
                                                metadata = metadata)
                 hidden_states, _ = afd_connector.recv_ffn_output()
                 
-            
-
-            # if dbo_enabled():
-            #     dbo_yield()
             hidden_states = apply_dbo_yield(hidden_states)
             
         if self.connector_name == "m2nconnector":
                 recv_hidden_states = afd_connector.recv_ffn_output(ubatch_hidden_states[ubatch_idx],
                                                                    ubatch_metadata[ubatch_idx],ubatch_idx)
-                # recv_hidden_states = afd_connector.recv_ffn_output(ubatch_hidden_states[ubatch_idx],
-                #                                                    ubatch_metadata[ubatch_idx],ubatch_idx)
         elif self.connector_name == "camm2nconnector":
             recv_hidden_states = afd_connector.recv_ffn_output(hidden_states,
                                                                 metadata,
@@ -1145,9 +1139,6 @@ class DeepseekV2Model(nn.Module):
             hidden_states, residual = self.forward_m2n(hidden_states, residual, positions, afd_metadata)
         else:
             for layer in islice(self.layers, self.start_layer, self.end_layer):
-                # if self.enforce_eager:
-                #     ubatch_idx = forward_ctx.ubatch_idx
-                #     logger.info(f"jcz deepseek forward_m2n layer_idx:{layer.layer_idx} ubatch_idx:{ubatch_idx}")
                 hidden_states, residual = layer(positions, hidden_states, residual)
                 hidden_states = apply_dbo_yield(hidden_states)
 
@@ -1508,26 +1499,22 @@ def get_spec_layer_idx_from_weight_name(config: Union[DeepseekV2Config,
 
 from vllm.utils import direct_register_custom_op
 
-# 1. 定义算子实现：接收 Tensor，执行副作用，返回 Tensor
+
 def manual_dbo_yield_op(x: torch.Tensor) -> torch.Tensor:
     if dbo_enabled():
         dbo_yield()
     return x
 
-# 2. 定义 Fake 实现：用于 Meta Tensor 推断 (torch.compile 需要)
-# Fake 实现只做形状推断，不执行实际逻辑
 def manual_dbo_yield_fake(x: torch.Tensor) -> torch.Tensor:
     return x
 
-# 3. 注册算子
-# 注意：op_name 只需要名字，不需要 "vllm::" 前缀，工具会自动处理
+
 direct_register_custom_op(
     op_name="manual_dbo_yield",
     op_func=manual_dbo_yield_op,
     fake_impl=manual_dbo_yield_fake,
-    mutates_args=[] # 该算子不修改输入 Tensor 的数值
+    mutates_args=[] 
 )
 
-# 封装调用辅助函数
 def apply_dbo_yield(x: torch.Tensor) -> torch.Tensor:
     return torch.ops.vllm.manual_dbo_yield(x)

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1072,6 +1072,7 @@ class DeepseekV2Model(nn.Module):
                 dtype=hidden_states.dtype,
                 device=hidden_states.device,
                 num_ubatches=forward_ctx.num_ubatches,
+                num_ubatches=forward_ctx.num_ubatches,
                 ffn_need_forward_data=ffn_need_forward_data,
                 m2n_afdconnector_data=m2n_afdconnector_data if self.connector_name == "m2nconnector" else None,
                 cam_m2n_afdconnector_data=cam_afdconnector_data if self.connector_name == "camm2nconnector" else None,
@@ -1083,11 +1084,7 @@ class DeepseekV2Model(nn.Module):
                 metadata.m2n_afdconnector_data.handle = handle
                 hidden_states = afd_connector.recv_ffn_output(hidden_states,metadata)
             elif self.connector_name == "camm2nconnector":
-                output_list = afd_connector.send_attn_output(current_hidden, topk_weights, topk_ids, metadata,forward_ctx.ubatch_idx)
-                hidden_states1, dynamic_scales, expandIdx, expertTokenNums, epRecvCounts, simulateExpertIds, simulateExpertScales, attenBatchSize = output_list[0:8]
-                handle = [simulateExpertIds, simulateExpertScales, expandIdx, epRecvCounts, attenBatchSize]
-                metadata.cam_m2n_afdconnector_data.handle = handle
-                hidden_states = afd_connector.recv_ffn_output(hidden_states, metadata)
+                hidden_states = afd_connector.send_attn_output(current_hidden, topk_weights, topk_ids, metadata)
             elif self.connector_name == "camp2pconnector":
                 output_list = afd_connector.send_attn_output(current_hidden, topk_weights, topk_ids, metadata)
                 hidden_states1, simulateExpertIds, simulateExpertScales, attenBatchSize, xActiveMaskOut = output_list[0:5]

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1072,7 +1072,6 @@ class DeepseekV2Model(nn.Module):
                 dtype=hidden_states.dtype,
                 device=hidden_states.device,
                 num_ubatches=forward_ctx.num_ubatches,
-                num_ubatches=forward_ctx.num_ubatches,
                 ffn_need_forward_data=ffn_need_forward_data,
                 m2n_afdconnector_data=m2n_afdconnector_data if self.connector_name == "m2nconnector" else None,
                 cam_m2n_afdconnector_data=cam_afdconnector_data if self.connector_name == "camm2nconnector" else None,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1071,6 +1071,7 @@ class DeepseekV2Model(nn.Module):
                 seq_len=hidden_states.shape[0],
                 dtype=hidden_states.dtype,
                 device=hidden_states.device,
+                num_ubatches=forward_ctx.num_ubatches,
                 ffn_need_forward_data=ffn_need_forward_data,
                 m2n_afdconnector_data=m2n_afdconnector_data if self.connector_name == "m2nconnector" else None,
                 cam_m2n_afdconnector_data=cam_afdconnector_data if self.connector_name == "camm2nconnector" else None,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1087,8 +1087,9 @@ class DeepseekV2Model(nn.Module):
                 
             
 
-            if dbo_enabled():
-                dbo_yield()
+            # if dbo_enabled():
+            #     dbo_yield()
+            hidden_states = apply_dbo_yield(hidden_states)
         return hidden_states, residual
 
     def forward(
@@ -1117,7 +1118,11 @@ class DeepseekV2Model(nn.Module):
             hidden_states, residual = self.forward_m2n(hidden_states, residual, positions, afd_metadata)
         else:
             for layer in islice(self.layers, self.start_layer, self.end_layer):
+                # if self.enforce_eager:
+                #     ubatch_idx = forward_ctx.ubatch_idx
+                #     logger.info(f"jcz deepseek forward_m2n layer_idx:{layer.layer_idx} ubatch_idx:{ubatch_idx}")
                 hidden_states, residual = layer(positions, hidden_states, residual)
+                hidden_states = apply_dbo_yield(hidden_states)
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({
@@ -1473,3 +1478,29 @@ def get_spec_layer_idx_from_weight_name(config: Union[DeepseekV2Config,
             if weight_name.startswith(f"model.layers.{layer_idx+i}."):
                 return layer_idx + i
     return None
+
+from vllm.utils import direct_register_custom_op
+
+# 1. 定义算子实现：接收 Tensor，执行副作用，返回 Tensor
+def manual_dbo_yield_op(x: torch.Tensor) -> torch.Tensor:
+    if dbo_enabled():
+        dbo_yield()
+    return x
+
+# 2. 定义 Fake 实现：用于 Meta Tensor 推断 (torch.compile 需要)
+# Fake 实现只做形状推断，不执行实际逻辑
+def manual_dbo_yield_fake(x: torch.Tensor) -> torch.Tensor:
+    return x
+
+# 3. 注册算子
+# 注意：op_name 只需要名字，不需要 "vllm::" 前缀，工具会自动处理
+direct_register_custom_op(
+    op_name="manual_dbo_yield",
+    op_func=manual_dbo_yield_op,
+    fake_impl=manual_dbo_yield_fake,
+    mutates_args=[] # 该算子不修改输入 Tensor 的数值
+)
+
+# 封装调用辅助函数
+def apply_dbo_yield(x: torch.Tensor) -> torch.Tensor:
+    return torch.ops.vllm.manual_dbo_yield(x)

--- a/vllm/v1/worker/dp_utils.py
+++ b/vllm/v1/worker/dp_utils.py
@@ -75,7 +75,6 @@ def _post_process_ubatch(tensor: torch.Tensor, num_ubatches: int) -> bool:
 
 def _post_process_dp_padding(tensor: torch.Tensor, should_dp_pad: bool) -> torch.Tensor:
     num_tokens_across_dp = tensor[1, :]
-    logger.info(f"jcz _post_process_dp_padding tensor:{tensor} should_dp_pad:{should_dp_pad}")
     if should_dp_pad:
         # If DP padding is enabled, ensure that each rank is processing the same number
         # of tokens

--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -14,7 +14,7 @@ from vllm.distributed import get_ep_group
 from vllm.distributed.device_communicators.pynccl_allocator import (
     set_graph_pool_id)
 from vllm.forward_context import (create_forward_context, get_forward_context,
-                                  override_forward_context)
+                                  override_forward_context, DPMetadata)
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
@@ -280,14 +280,25 @@ class UBatchWrapper:
         # Create one forward context per ubatch
         forward_contexts = []
         for i, ubatch_slice in enumerate(ubatch_slices):
+            dp_size = self.vllm_config.parallel_config.data_parallel_size
+            ubatch_num_tokens_across_dp = torch.tensor(
+                [ubatch_slice.num_tokens] * dp_size, device="cpu", dtype=torch.int32
+            )
+            ubatch_dp_metadata = DPMetadata.make(
+                self.vllm_config.parallel_config,
+                ubatch_slice.num_tokens,
+                ubatch_num_tokens_across_dp,
+            )
             forward_contexts.append(
                 create_forward_context(
                     attn_metadata[i] if attn_metadata is not None else None,
                     self.vllm_config,
-                    dp_metadata=dp_metadata,
+                    dp_metadata=ubatch_dp_metadata,
+                    # dp_metadata=dp_metadata,
                     batch_descriptor=batch_descriptor,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
-                    afd_metadata=afd_metadata
+                    afd_metadata=afd_metadata,
+                    ubatch_idx=i
                 )
             )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
DBO+aclgrph 
## Test Plan
```
#!/bin/bash
# python -m debugpy --listen 56306 --wait-for-client $(which vllm) serve /home/y00889327/DSV2LiteWeight \
# vllm serve /home/y00889327/DSV2LiteWeight \
# vllm serve /home/y00889327/DSV2LiteWeight \
#    --enable-dbo \
#    --dbo-prefill-token-threshold 12 \
#    --dbo-decode-token-threshold 2 \
# --tensor-parallel-size 2 \
# --data-parallel-size 2 \
# --enforce-eager \
# --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[20]}'  \
#python -m debugpy --listen 56307 --wait-for-client -m vllm.entrypoints.afd_ffn_server /home/y00889327/DSV2LiteWeight\
# 用法说明
usage() {
    echo "用法: $0 [-a ATTENTION_DEVICES] [-f FFN_DEVICES] [-h]"
    echo "  参数:"
    echo "    -a ATTENTION_DEVICES  attention服务器使用的卡号（默认: 2,3）"
    echo "    -f FFN_DEVICES        ffn服务器使用的卡号（默认: 0,1）"
    echo "    -h                    显示帮助信息"
    echo ""
    echo "示例:"
    echo "  $0 -a 0,1 -f 2,3        使用卡0,1运行attention，卡2,3运行ffn"
    echo "  $0                      使用默认配置（卡2,3运行attention，卡0,1运行ffn）"
    exit 1
}

# 默认值
ATTENTION_DEVICES="14,15"
FFN_DEVICES="12,13"

# 解析命令行参数
while getopts "a:f:h" opt; do
    case $opt in
        a) ATTENTION_DEVICES="$OPTARG" ;;
        f) FFN_DEVICES="$OPTARG" ;;
        h) usage ;;
        \?) echo "无效选项: -$OPTARG" >&2; usage ;;
        :) echo "选项 -$OPTARG 需要参数" >&2; usage ;;
    esac
done

# 检查卡号是否冲突
check_device_conflict() {
    local dev1_arr=(${1//,/ })
    local dev2_arr=(${2//,/ })
    
    for dev1 in "${dev1_arr[@]}"; do
        for dev2 in "${dev2_arr[@]}"; do
            if [ "$dev1" = "$dev2" ]; then
                echo "错误: attention和ffn服务器使用了相同的卡号: $dev1"
                echo "请确保两个服务器使用不同的卡号"
                exit 1
            fi
        done
    done
}

# 检查卡号冲突
check_device_conflict "$ATTENTION_DEVICES" "$FFN_DEVICES"

echo "配置:"
echo "  Attention服务器卡号: $ATTENTION_DEVICES"
echo "  FFN服务器卡号: $FFN_DEVICES"
echo ""

# 设置公共环境变量
export HCCL_BUFFSIZE=4096
export VLLM_LOGGING_LEVEL=DEBUG

# 日志文件路径
LOG_DIR="/home/y00889327/workspace-afd/test-vllm-ascend"
ATTENTION_LOG="$LOG_DIR/attn_${ATTENTION_DEVICES//,/_}.log"
FFN_LOG="$LOG_DIR/ffn_${FFN_DEVICES//,/_}.log"

# 确保日志目录存在
mkdir -p "$LOG_DIR"

# 启动attention服务器
echo "=== 启动attention服务器（卡号: $ATTENTION_DEVICES）==="
export ASCEND_RT_VISIBLE_DEVICES="$ATTENTION_DEVICES"
nohup vllm serve /home/y00889327/DSV2LiteWeight \
    --data-parallel-size 2 \
    --max_num_batched_tokens 20 \
    --max_num_seqs 20 \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[20]}'  \
    --enable-dbo \
    --dbo-prefill-token-threshold 12 \
    --dbo-decode-token-threshold 2 \
    --port 8006 \
    --max-model-len 4096 \
    --afd-config '{"afd_connector":"camm2nconnector", "afd_role": "attention", "num_afd_stages":"2","afd_extra_config":{"afd_size":"2A2F"}, "compute_gate_on_attention": "True","afd_port":"29666"}' \
    > "$ATTENTION_LOG" 2>&1 &
ATTENTION_PID=$!

# 记录PID
echo "attention服务器PID: $ATTENTION_PID"
echo "日志文件: $ATTENTION_LOG"

# 启动ffn服务器
echo ""
echo "=== 启动ffn服务器（卡号: $FFN_DEVICES）==="
export ASCEND_RT_VISIBLE_DEVICES="$FFN_DEVICES"
nohup python -m vllm.entrypoints.afd_ffn_server /home/y00889327/DSV2LiteWeight\
    --tensor-parallel-size 2 \
    --enable_expert_parallel \
    --max_num_batched_tokens 20 \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[20]}'  \
    --enable-dbo \
    --dbo-prefill-token-threshold 12 \
    --dbo-decode-token-threshold 2 \
    --max_num_seqs 20 \
    --max-model-len 4096 \
    --afd-config '{"afd_connector":"camm2nconnector", "num_afd_stages":"2", "afd_role": "ffn", "afd_extra_config":{"afd_size":"2A2F"}, "compute_gate_on_attention": "True","afd_port":"29666"}' \
    > "$FFN_LOG" 2>&1 &
FFN_PID=$!

# 记录PID
echo "ffn服务器PID: $FFN_PID"
echo "日志文件: $FFN_LOG"

# 保存PID到文件，方便后续管理
PIDS_FILE="$LOG_DIR/server_pids_$(date +%Y%m%d_%H%M%S).txt"
echo "ATTENTION_PID=$ATTENTION_PID" > "$PIDS_FILE"
echo "FFN_PID=$FFN_PID" >> "$PIDS_FILE"
echo "ATTENTION_LOG=$ATTENTION_LOG" >> "$PIDS_FILE"
echo "FFN_LOG=$FFN_LOG" >> "$PIDS_FILE"
echo "ATTENTION_DEVICES=$ATTENTION_DEVICES" >> "$PIDS_FILE"
echo "FFN_DEVICES=$FFN_DEVICES" >> "$PIDS_FILE"

echo ""
echo "=== 服务器启动完成 ==="
echo "两个服务器已同时拉起并运行在后台"
echo "PID文件: $PIDS_FILE"
echo ""
echo "监控日志:"
echo "  tail -f $ATTENTION_LOG"
echo "  tail -f $FFN_LOG"
echo ""
echo "停止服务器:"
echo "  kill $ATTENTION_PID $FFN_PID"
echo "或使用停止脚本: $0 stop (如果实现了停止功能)"

# 提供一个简单的监控选项
read -p "是否打开实时日志监控? (y/n): " -n 1 -r
echo ""
if [[ $REPLY =~ ^[Yy]$ ]]; then
    echo "=== 实时日志监控（Ctrl+C退出监控，服务器继续运行）==="
    echo "注意: 按 Ctrl+C 只退出监控，服务器继续在后台运行"
    echo ""
    
    # 检查是否安装了multitail
    if command -v multitail &> /dev/null; then
        multitail -s 2 \
            -l "tail -f $ATTENTION_LOG" \
            -l "tail -f $FFN_LOG" \
            -cs attention -T "Attention Server ($ATTENTION_DEVICES)" \
            -cs ffn -T "FFN Server ($FFN_DEVICES)"
    else
        echo "ATTENTION 服务器日志 ($ATTENTION_DEVICES):"
        echo "FFN 服务器日志 ($FFN_DEVICES):"
        echo "----------------------------------------"
        # 使用简单的tail -f同时查看两个日志
        (tail -f "$ATTENTION_LOG" & tail -f "$FFN_LOG") | awk '/^==>/ {print "\033[32m" $0 "\033[0m"; next} {print}'
    fi
fi

```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

