### PR TITLE
AFDConnector, ubatch refactor

### DIFF
--- a/vllm/distributed/afd_transfer/afd_connector/base.py
+++ b/vllm/distributed/afd_transfer/afd_connector/base.py
@@ -73,17 +73,27 @@ class AFDConnectorBase(ABC):
         """Get the local rank of this connector."""
         return getattr(self, 'local_rank', 0)
 
+    def configure_metadata(self, metadata: "AFDConnectorMetadata", **kwargs) -> None:
+        """
+        Allow connector to inject specific data into metadata.
+        Base implementation does nothing.
+        """
+        pass
+
     @abstractmethod
     def send_attn_output(
         self,
         hidden_states: torch.Tensor,
         metadata: "AFDConnectorMetadata",
+        **kwargs
     ) -> Any:
         """Send attention output to FFN servers.
         
         Args:
             hidden_states: Attention output tensor
             metadata: AFD metadata containing layer_idx, stage_idx, seq_len info
+            **kwargs: Additional arguments required by specific connectors 
+                      (e.g. topk_weights, topk_ids, router_logits)
             
         Returns:
             Any: Handle for tracking this request (backend-specific)
@@ -93,27 +103,31 @@ class AFDConnectorBase(ABC):
     @abstractmethod
     def recv_ffn_output(
         self,
-        handle: Any,
-    ) -> torch.Tensor:
+        hidden_states: Optional[torch.Tensor] = None,
+        metadata: Optional["AFDConnectorMetadata"] = None
+    ) -> Optional[torch.Tensor]:
         """Wait for and receive FFN computation result.
         
         Args:
-            handle: Handle returned by send_attn_output()
+            hidden_states: Optional hidden states tensor (used by some connectors)
+            metadata: Optional metadata
             
         Returns:
-            torch.Tensor: FFN computation result
+            torch.Tensor: FFN computation result.
         """
         raise NotImplementedError
 
     @abstractmethod
     def recv_attn_output(
         self,
-        timeout_ms: Optional[int] = None,
+        metadata: Optional["AFDConnectorMetadata"] = None,
+        **kwargs
     ) -> tuple[torch.Tensor, "AFDConnectorMetadata"]:
         """Receive attention output from attention workers.
         
         Args:
-            timeout_ms: Optional timeout in milliseconds
+            metadata: Optional metadata
+            **kwargs: Additional arguments
             
         Returns:
             tuple: (hidden_states, metadata)
@@ -128,6 +142,7 @@ class AFDConnectorBase(ABC):
         self,
         ffn_output: torch.Tensor,
         metadata: "AFDConnectorMetadata",
+        **kwargs
     ) -> None:
         """Send FFN computation result back to attention workers.
         
@@ -135,5 +150,55 @@ class AFDConnectorBase(ABC):
             ffn_output: Computed FFN result
             metadata: AFD metadata containing seq_lens 
                       for splitting and routing info
+            **kwargs: Additional arguments
         """
         raise NotImplementedError
+
+    def compute_moe(
+        self,
+        experts: torch.nn.Module,
+        hidden_states: torch.Tensor,
+        **kwargs
+    ) -> Any:
+        """
+        Perform MoE computation via the connector (or delegate to experts).
+        Default implementation calls experts.afd_ffn_compute.
+        Connectors can override to call different methods on experts.
+        """
+        return experts.afd_ffn_compute(
+            layer=experts,
+            hidden_states=hidden_states,
+            **kwargs
+        )
+
+    def select_experts(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        top_k: int,
+        use_grouped_topk: bool,
+        renormalize: bool,
+        topk_group: Optional[int] = None,
+        num_expert_group: Optional[int] = None,
+        custom_routing_function: Optional[Any] = None,
+        e_score_correction_bias: Optional[torch.Tensor] = None,
+        **kwargs
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Select experts for MoE.
+        
+        Args:
+            hidden_states: Input hidden states
+            router_logits: Router logits
+            top_k: Number of experts to select
+            use_grouped_topk: Whether to use grouped topk
+            renormalize: Whether to renormalize weights
+            topk_group: Number of groups for topk
+            num_expert_group: Number of expert groups
+            custom_routing_function: Custom routing function
+            e_score_correction_bias: Bias for score correction
+            
+        Returns:
+             tuple: (topk_weights, topk_ids, row_idx)
+        """
+        raise NotImplementedError("select_experts not implemented for this connector")

--- a/vllm/distributed/afd_transfer/afd_connector/factory.py
+++ b/vllm/distributed/afd_transfer/afd_connector/factory.py
@@ -17,6 +17,7 @@ logger = init_logger(__name__)
 
 class AFDConnectorFactory:
     _registry: dict[str, Callable[[], type[AFDConnectorBase]]] = {}
+    _plugins_loaded: bool = False
 
     @classmethod
     def register_connector(cls, name: str, module_path: str,
@@ -35,19 +36,20 @@ class AFDConnectorFactory:
     def create_connector(cls, rank: int, local_rank: int,
                          config: "VllmConfig") -> AFDConnectorBase:
         """Create an AFD connector based on the configuration.
-        
+
         Args:
             rank: Global rank of this process
             local_rank: Local rank within the node
             config: VllmConfig containing AFDConfig
-            
+
         Returns:
             AFDConnectorBase: The created connector instance
-            
+
         Raises:
             ValueError: If the transport backend is not supported
             ImportError: If required dependencies are not available
         """
+        cls.load_plugins()
         afd_config = config.afd_config
         connector_name = afd_config.afd_connector
 
@@ -62,20 +64,50 @@ class AFDConnectorFactory:
     def get_connector_class(cls,
                             connector_name: str) -> type[AFDConnectorBase]:
         """Get the connector class for a given connector name.
-        
+
         Args:
             connector_name: The connector name
-            
+
         Returns:
             type[AFDConnectorBase]: The connector class
-            
+
         Raises:
             ValueError: If the connector name is not supported
         """
+        cls.load_plugins()
         if connector_name not in cls._registry:
             raise ValueError(f"Unsupported connector type: {connector_name}")
 
         return cls._registry[connector_name]()
+
+    @classmethod
+    def load_plugins(cls):
+        """Load connectors from entry points."""
+        if cls._plugins_loaded:
+            return
+        cls._plugins_loaded = True
+
+        import sys
+        if sys.version_info < (3, 10):
+            from importlib.metadata import entry_points
+            eps = entry_points()
+            if "vllm.afd_connectors" in eps:
+                plugin_eps = eps["vllm.afd_connectors"]
+            else:
+                plugin_eps = []
+        else:
+            from importlib.metadata import entry_points
+            plugin_eps = entry_points(group="vllm.afd_connectors")
+
+        for entry_point in plugin_eps:
+            try:
+                register_func = entry_point.load()
+                register_func()
+                logger.info(f"Loaded AFD connector plugin: {entry_point.name}")
+            except Exception as e:
+                logger.warning(
+                    f"Failed to load AFD connector plugin {entry_point.name}: {e}"
+                )
 
 
 # Register various connectors here.
@@ -93,15 +125,3 @@ AFDConnectorFactory.register_connector(
 AFDConnectorFactory.register_connector(
     "p2pconnector", "vllm.distributed.afd_transfer.afd_connector.p2p_connector",
     "P2PAFDConnector")
-
-AFDConnectorFactory.register_connector(
-    "m2nconnector", "vllm_ascend.distributed.M2NAFDConnector",
-    "M2NAFDConnector")
-
-AFDConnectorFactory.register_connector(
-    "camm2nconnector", "vllm_ascend.distributed.CAMM2NAFDConnector",
-    "CAMM2NAFDConnector")
-
-AFDConnectorFactory.register_connector(
-    "camp2pconnector", "vllm_ascend.distributed.CAMP2PAFDConnector",
-    "CAMP2PAFDConnector")

--- a/vllm/distributed/afd_transfer/afd_connector/metadata.py
+++ b/vllm/distributed/afd_transfer/afd_connector/metadata.py
@@ -11,11 +11,6 @@ import torch
 
 from abc import ABC, abstractmethod
 
-#TODO(yxj):move to AFDExtraFields
-# from vllm_ascend.ascend_forward_context import MoECommType
-from dataclasses import dataclass, field
-from typing import Dict
-
 
 class AFDRecvHandle(ABC):
     """
@@ -40,20 +35,6 @@ class AFDRecvHandle(ABC):
         Blocks until the data transfer or computation is finished.
         """
         raise NotImplementedError
-
-
-class FFNNeedForwardData:
-    def __init__(self,
-                 moe_comm_type: Any = None,
-                 num_input_tokens:int = 0,
-                 with_prefill:bool = False,
-                 total_num_scheduled_tokens:int = 0,
-                 is_dummy_run:bool = False):
-        self.moe_comm_type = moe_comm_type
-        self.num_input_tokens = num_input_tokens
-        self.with_prefill = with_prefill
-        self.total_num_scheduled_tokens = total_num_scheduled_tokens
-        self.is_dummy_run = is_dummy_run
 
 
 @dataclass
@@ -110,9 +91,6 @@ class AFDConnectorMetadata:
     send_handle_list: Optional[list[Any]] = None # the communication handles (list of Work objects returned by torch.distributed.isend)
     recv_handle_list: Optional[list[Any]] = None # the communication handles (list of Work objects returned by torch.distributed.irecv)
 
-    # TODO(jcz): need fix vllm_ascend dependency
-    ffn_need_forward_data: Optional[FFNNeedForwardData] = None
-    
     # Optional fields for debugging and extensibility
     request_id: Optional[str] = None
     timestamp: Optional[float] = None
@@ -154,7 +132,6 @@ class AFDConnectorMetadata:
             device: torch.device,
             num_ubatches: int = 1,
             request_id: Optional[str] = None,
-            ffn_need_forward_data:Optional[FFNNeedForwardData] = None,
             connector_data: Any = None,
             topk_weights: Optional[torch.Tensor] = None,
             topk_ids: Optional[torch.Tensor] = None,
@@ -169,7 +146,6 @@ class AFDConnectorMetadata:
                    num_ubatches=num_ubatches,
                    request_id=request_id,
                 #    timestamp=time.time(),
-                   ffn_need_forward_data=ffn_need_forward_data,
                    connector_data=connector_data,
                    topk_weights=topk_weights,
                    topk_ids=topk_ids,

--- a/vllm/distributed/afd_transfer/afd_connector/metadata.py
+++ b/vllm/distributed/afd_transfer/afd_connector/metadata.py
@@ -37,6 +37,10 @@ class AFDRecvHandle(ABC):
         raise NotImplementedError
 
 
+class AFDConnectorData(ABC):
+    """Base class for connector-specific metadata objects."""
+
+
 @dataclass
 class AFDRecvOutput:
     """Standardized output for recv_attn_output across all connectors."""
@@ -78,7 +82,7 @@ class AFDConnectorMetadata:
     num_ubatches: int = 1
     
     # Generic field for connector-specific data
-    connector_data: Any = None
+    connector_data: Optional["AFDConnectorData"] = None
     
     topk_idx: Optional[torch.Tensor] = None # indices token which expert to be sended
     topk_weights: Optional[torch.Tensor] = None # the expert weights
@@ -132,7 +136,7 @@ class AFDConnectorMetadata:
             device: torch.device,
             num_ubatches: int = 1,
             request_id: Optional[str] = None,
-            connector_data: Any = None,
+            connector_data: Optional["AFDConnectorData"] = None,
             topk_weights: Optional[torch.Tensor] = None,
             topk_ids: Optional[torch.Tensor] = None,
             row_idx: Optional[torch.Tensor] = None,

--- a/vllm/distributed/afd_transfer/afd_connector/metadata.py
+++ b/vllm/distributed/afd_transfer/afd_connector/metadata.py
@@ -12,7 +12,7 @@ import torch
 from abc import ABC, abstractmethod
 
 #TODO(yxj):move to AFDExtraFields
-from vllm_ascend.ascend_forward_context import MoECommType
+# from vllm_ascend.ascend_forward_context import MoECommType
 from dataclasses import dataclass, field
 from typing import Dict
 
@@ -44,7 +44,7 @@ class AFDRecvHandle(ABC):
 
 class FFNNeedForwardData:
     def __init__(self,
-                 moe_comm_type:Optional[MoECommType] = None,
+                 moe_comm_type: Any = None,
                  num_input_tokens:int = 0,
                  with_prefill:bool = False,
                  total_num_scheduled_tokens:int = 0,
@@ -53,61 +53,35 @@ class FFNNeedForwardData:
         self.num_input_tokens = num_input_tokens
         self.with_prefill = with_prefill
         self.total_num_scheduled_tokens = total_num_scheduled_tokens
+        self.is_dummy_run = is_dummy_run
 
 
 @dataclass
-class M2NAFDConnectorMetadata:
-    def __init__(self):
-        self.topk_idx = None
-        self.topk_weights = None
-        self.moe_expert_num = 0
-        self.scale = None
-        self.handle = None
-        self.quant_mode = 0
-        self.aiv_num = 0
-        self.batch_size = 0
-        self.h = 0
-        self.k = 0
-        self.expert_token_nums_type = 0
-        self.expand_x_type = torch.float16
-        
-@dataclass
-class CAMM2NAFDConnectorMetadata:
-    def __init__(self, moe_expert_num=0,
-        shared_expert_num = 0, scale=None, handle=None, quant_mode=0,
-        aiv_num=0, batch_size=0, h=0, k=0):
-        self.moe_expert_num = moe_expert_num
-        self.shared_expert_num = shared_expert_num
-        self.scale = scale
-        self.handle = handle
-        self.quant_mode = quant_mode
-        self.aiv_num = aiv_num
-        self.batch_size = batch_size
-        self.h = h
-        self.k = k
+class AFDRecvOutput:
+    """Standardized output for recv_attn_output across all connectors."""
+    hidden_states: torch.Tensor
+    metadata: Optional[Any] = None  # AFDConnectorMetadata
+    
+    # Common / Shared fields
+    topk_weights: Optional[torch.Tensor] = None
+    topk_ids: Optional[torch.Tensor] = None
+    dynamic_scales: Optional[torch.Tensor] = None
+    group_list: Optional[torch.Tensor] = None
+    
+    # M2N specific
+    handle: Optional[Any] = None 
+    
+    # P2P specific
+    router_logits: Optional[torch.Tensor] = None
+    row_idx: Optional[torch.Tensor] = None
+    
+    # CAM specific fields (mapped from raw lists)
+    expand_idx: Optional[torch.Tensor] = None
+    ep_recv_counts: Optional[torch.Tensor] = None
+    atten_batch_size: Optional[torch.Tensor] = None
+    x_active_mask: Optional[torch.Tensor] = None
+    cam_p2p_ep_name: Optional[str] = None
 
-@dataclass
-class CAMP2PAFDConnectorMetadata:
-    def __init__(self, moe_expert_num=0,
-        shared_expert_num = 0, scale=None, handle=None, quant_mode=0,
-        aiv_num=0, batch_size=0, h=0, k=0):
-        self.moe_expert_num = moe_expert_num
-        self.shared_expert_num = shared_expert_num
-        self.scale = scale
-        self.handle = handle
-        self.quant_mode = quant_mode
-        self.aiv_num = aiv_num
-        self.batch_size = batch_size
-        self.h = h
-        self.k = k
-
-@dataclass
-class AFDExtraFields:
-    """Additional field specifically for storing AFDconnectors"""
-    custom_fields: Dict[str, Any] = field(default_factory=dict)
-
-    def __init__(self, **kwargs):
-        self.custom_fields.update(kwargs)
 
 @dataclass
 class AFDConnectorMetadata:
@@ -121,8 +95,14 @@ class AFDConnectorMetadata:
     dtype: torch.dtype
     device: torch.device
     num_ubatches: int = 1
+    
+    # Generic field for connector-specific data
+    connector_data: Any = None
+    
     topk_idx: Optional[torch.Tensor] = None # indices token which expert to be sended
     topk_weights: Optional[torch.Tensor] = None # the expert weights
+    topk_ids: Optional[torch.Tensor] = None
+    row_idx: Optional[torch.Tensor] = None
     moe_expert_num: Optional[int] = None # number of moe experts
     shared_expert_num: Optional[int] = None # number of share experts
     scale: Optional[torch.Tensor] = None #  quant scale
@@ -132,12 +112,6 @@ class AFDConnectorMetadata:
 
     # TODO(jcz): need fix vllm_ascend dependency
     ffn_need_forward_data: Optional[FFNNeedForwardData] = None
-    m2n_afdconnector_data: Optional[M2NAFDConnectorMetadata] = None
-    cam_m2n_afdconnector_data: Optional[CAMM2NAFDConnectorMetadata] = None
-    cam_p2p_afdconnector_data: Optional[CAMP2PAFDConnectorMetadata] = None
-    topk_weights: Optional[torch.Tensor] = None
-    topk_ids: Optional[torch.Tensor] = None
-    row_idx: Optional[torch.Tensor] = None
     
     # Optional fields for debugging and extensibility
     request_id: Optional[str] = None
@@ -181,13 +155,11 @@ class AFDConnectorMetadata:
             num_ubatches: int = 1,
             request_id: Optional[str] = None,
             ffn_need_forward_data:Optional[FFNNeedForwardData] = None,
-            m2n_afdconnector_data:Optional[M2NAFDConnectorMetadata] = None,
-            cam_m2n_afdconnector_data:Optional[CAMM2NAFDConnectorMetadata] = None,
-            cam_p2p_afdconnector_data:Optional[CAMP2PAFDConnectorMetadata] = None,
-            # extra_fields: AFDExtraFields = field(default_factory=AFDExtraFields),
+            connector_data: Any = None,
             topk_weights: Optional[torch.Tensor] = None,
             topk_ids: Optional[torch.Tensor] = None,
-            row_idx: Optional[torch.Tensor] = None) -> "AFDConnectorMetadata":
+            row_idx: Optional[torch.Tensor] = None,
+            **kwargs) -> "AFDConnectorMetadata":
         """Create metadata for attention side (single sequence)."""
         return cls(layer_idx=layer_idx,
                    stage_idx=stage_idx,
@@ -198,9 +170,7 @@ class AFDConnectorMetadata:
                    request_id=request_id,
                 #    timestamp=time.time(),
                    ffn_need_forward_data=ffn_need_forward_data,
-                   m2n_afdconnector_data=m2n_afdconnector_data,
-                   cam_m2n_afdconnector_data=cam_m2n_afdconnector_data,
-                   cam_p2p_afdconnector_data=cam_p2p_afdconnector_data,
+                   connector_data=connector_data,
                    topk_weights=topk_weights,
                    topk_ids=topk_ids,
                    row_idx=row_idx,

--- a/vllm/distributed/afd_transfer/afd_connector/p2p_connector.py
+++ b/vllm/distributed/afd_transfer/afd_connector/p2p_connector.py
@@ -251,7 +251,7 @@ class P2PAFDConnector(AFDConnectorBase):
         except Exception as e:
             raise RuntimeError(f"Communication error: {e}")
 
-    def recv_attn_output(self) -> IntermediateTensors:
+    def recv_attn_output(self) -> Any:
         """
         This method will be called by the FFN side.
 
@@ -270,10 +270,28 @@ class P2PAFDConnector(AFDConnectorBase):
         # Asynchronously receive independent metadata
         metadata = self.a2e_group.recv_object(src)
         metadata.recv_handle_list = work_list
+        
+        from vllm.distributed.afd_transfer.afd_connector.metadata import AFDRecvOutput
         if self.backend == "hccl":
-            return intermediate_tensors["hidden_states"],intermediate_tensors["router_logits"],intermediate_tensors["topk_weights"],intermediate_tensors["topk_ids"],intermediate_tensors["row_idx"], metadata
+            return AFDRecvOutput(
+                hidden_states=intermediate_tensors["hidden_states"],
+                metadata=metadata,
+                router_logits=intermediate_tensors["router_logits"],
+                topk_weights=intermediate_tensors["topk_weights"],
+                topk_ids=intermediate_tensors["topk_ids"],
+                row_idx=intermediate_tensors["row_idx"]
+            )
         else:
-            return intermediate_tensors["hidden_states"], metadata
+            return AFDRecvOutput(
+                hidden_states=intermediate_tensors["hidden_states"],
+                metadata=metadata
+            )
+
+    def create_recv_metadata(self, **kwargs):
+        return None
+
+    def update_metadata(self, metadata, recv_output):
+        pass
 
     # -------------------------------------------------------------------------
     #                                attn <- ffn

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -66,25 +66,25 @@ from .utils import (PPMissingLayer, is_pp_missing_parameter,
                     maybe_prefix)
 
 from vllm.logger import init_logger
+
 logger = init_logger(__name__)
 
 from vllm.forward_context import get_forward_context
 from vllm.forward_context import AFDMetadata
-# TODO(jcz): need remove vllm_ascend dependency
-from vllm_ascend.ops.moe.experts_selector import select_experts
-from vllm_ascend.worker.ubatching import dbo_current_ubatch_id, dbo_yield, dbo_enabled
+from vllm.v1.worker.ubatching import dbo_yield, dbo_enabled
+
 
 class DeepseekV2MLP(nn.Module):
 
     def __init__(
-        self,
-        hidden_size: int,
-        intermediate_size: int,
-        hidden_act: str,
-        quant_config: Optional[QuantizationConfig] = None,
-        reduce_results: bool = True,
-        is_sequence_parallel=False,
-        prefix: str = "",
+            self,
+            hidden_size: int,
+            intermediate_size: int,
+            hidden_act: str,
+            quant_config: Optional[QuantizationConfig] = None,
+            reduce_results: bool = True,
+            is_sequence_parallel=False,
+            prefix: str = "",
     ) -> None:
         super().__init__()
 
@@ -120,12 +120,12 @@ class DeepseekV2MLP(nn.Module):
 class DeepseekV2MoE(nn.Module):
 
     def __init__(
-        self,
-        config: Union[DeepseekV2Config, DeepseekV3Config],
-        parallel_config: ParallelConfig,
-        quant_config: Optional[QuantizationConfig] = None,
-        prefix: str = "",
-        is_mtp=False,
+            self,
+            config: Union[DeepseekV2Config, DeepseekV3Config],
+            parallel_config: ParallelConfig,
+            quant_config: Optional[QuantizationConfig] = None,
+            prefix: str = "",
+            is_mtp=False,
     ):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
@@ -148,10 +148,10 @@ class DeepseekV2MoE(nn.Module):
         self.afd_config = getattr(vllm_config, "afd_config", None)
         if self.afd_config is None or not self.afd_config.compute_gate_on_attention or is_mtp:
             self.gate = ReplicatedLinear(config.hidden_size,
-                                        config.n_routed_experts,
-                                        bias=False,
-                                        quant_config=None,
-                                        prefix=f"{prefix}.gate")
+                                         config.n_routed_experts,
+                                         bias=False,
+                                         quant_config=None,
+                                         prefix=f"{prefix}.gate")
             if config.topk_method == "noaux_tc":
                 self.gate.e_score_correction_bias = nn.Parameter(
                     torch.empty(config.n_routed_experts, dtype=torch.float32))
@@ -286,20 +286,19 @@ class DeepseekV2MoE(nn.Module):
                     final_hidden_states))
 
         return final_hidden_states.view(num_tokens, hidden_dim)
-    
 
     def afd_forward(
-        self, 
-        hidden_states: torch.Tensor,
-        router_logits:  Optional[torch.Tensor] = None,
-        group_list:  Optional[torch.Tensor] = None,
-        dynamic_scales:  Optional[torch.Tensor] = None,
-        topk_weights: Optional[torch.Tensor] = None,
-        topk_ids: Optional[torch.Tensor] = None,
-        row_idx: Optional[torch.Tensor] = None,
-        x_active_mask: Optional[torch.Tensor] = None,
-        cam_p2p_ep_name: Optional[str] = "",
-        ) -> torch.Tensor:
+            self,
+            hidden_states: torch.Tensor,
+            router_logits: Optional[torch.Tensor] = None,
+            group_list: Optional[torch.Tensor] = None,
+            dynamic_scales: Optional[torch.Tensor] = None,
+            topk_weights: Optional[torch.Tensor] = None,
+            topk_ids: Optional[torch.Tensor] = None,
+            row_idx: Optional[torch.Tensor] = None,
+            x_active_mask: Optional[torch.Tensor] = None,
+            cam_p2p_ep_name: Optional[str] = "",
+    ) -> torch.Tensor:
         num_tokens, hidden_dim = hidden_states.shape
         # TODO(yxj ):dynamic_scales --> dynamic_scale
 
@@ -307,33 +306,32 @@ class DeepseekV2MoE(nn.Module):
         set_substitute_tp(1)
         self.tp_size = get_tensor_model_parallel_world_size()
         self.tp_rank = get_tensor_model_parallel_rank()
-        if self.connector_name == "m2nconnector" or self.connector_name == "camm2nconnector":
-            fused_moe_out = self.experts.afd_m2n_ffn_compute(
-                layer=self.experts,  
-                hidden_states=hidden_states,  
-                group_list=group_list, 
-                dynamic_scale=dynamic_scales,
-                connector_name=self.connector_name
-                )
-        elif self.connector_name == "camp2pconnector":
-            fused_moe_out = self.experts.afd_m2n_ffn_compute(
-                layer=self.experts,  
-                hidden_states=hidden_states,  
-                topk_ids=topk_ids,
+
+        forward_ctx = get_forward_context()
+        if forward_ctx and forward_ctx.afd_metadata and forward_ctx.afd_metadata.afd_connector:
+            afd_connector = forward_ctx.afd_metadata.afd_connector
+            fused_moe_out = afd_connector.compute_moe(
+                experts=self.experts,
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+                group_list=group_list,
+                dynamic_scales=dynamic_scales,
                 topk_weights=topk_weights,
-                connector_name=self.connector_name,
+                topk_ids=topk_ids,
+                row_idx=row_idx,
                 x_active_mask=x_active_mask,
-                cam_p2p_ep_name=cam_p2p_ep_name
-                )
+                cam_p2p_ep_name=cam_p2p_ep_name,
+                connector_name=self.connector_name
+            )
         else:
             fused_moe_out = self.experts.afd_ffn_compute(
-                layer=self.experts, 
-                hidden_states=hidden_states, 
-                router_logits=router_logits, 
-                topk_weights=topk_weights, 
-                topk_ids=topk_ids, 
+                layer=self.experts,
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
                 row_idx=row_idx)
-        
+
         if self.shared_experts is not None:
             shared_output, final_hidden_states = fused_moe_out
         else:
@@ -375,21 +373,21 @@ def yarn_get_mscale(scale: float = 1, mscale: float = 1) -> float:
 class DeepseekV2Attention(nn.Module):
 
     def __init__(
-        self,
-        config: Union[DeepseekV2Config, DeepseekV3Config],
-        hidden_size: int,
-        num_heads: int,
-        qk_nope_head_dim: int,
-        qk_rope_head_dim: int,
-        v_head_dim: int,
-        q_lora_rank: int,
-        kv_lora_rank: int,
-        rope_theta: float = 10000,
-        rope_scaling: Optional[dict[str, Any]] = None,
-        max_position_embeddings: int = 8192,
-        cache_config: Optional[CacheConfig] = None,
-        quant_config: Optional[QuantizationConfig] = None,
-        prefix: str = "",
+            self,
+            config: Union[DeepseekV2Config, DeepseekV3Config],
+            hidden_size: int,
+            num_heads: int,
+            qk_nope_head_dim: int,
+            qk_rope_head_dim: int,
+            v_head_dim: int,
+            q_lora_rank: int,
+            kv_lora_rank: int,
+            rope_theta: float = 10000,
+            rope_scaling: Optional[dict[str, Any]] = None,
+            max_position_embeddings: int = 8192,
+            cache_config: Optional[CacheConfig] = None,
+            quant_config: Optional[QuantizationConfig] = None,
+            prefix: str = "",
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -403,7 +401,7 @@ class DeepseekV2Attention(nn.Module):
         tp_size = get_tensor_model_parallel_world_size()
         assert num_heads % tp_size == 0
         self.num_local_heads = num_heads // tp_size
-        self.scaling = self.qk_head_dim**-0.5
+        self.scaling = self.qk_head_dim ** -0.5
         self.rope_theta = rope_theta
         self.max_position_embeddings = max_position_embeddings
 
@@ -474,9 +472,9 @@ class DeepseekV2Attention(nn.Module):
                               prefix=f"{prefix}.attn")
 
     def forward(
-        self,
-        positions: torch.Tensor,
-        hidden_states: torch.Tensor,
+            self,
+            positions: torch.Tensor,
+            hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         if self.q_lora_rank is not None:
             q = self.q_a_proj(hidden_states)[0]
@@ -513,7 +511,7 @@ class DeepseekV2Attention(nn.Module):
         attn_output = attn_output.view(
             -1, self.num_local_heads,
             self.qk_head_dim)[..., :self.v_head_dim].reshape(
-                -1, self.num_local_heads * self.v_head_dim)
+            -1, self.num_local_heads * self.v_head_dim)
         output, _ = self.o_proj(attn_output)
         return output
 
@@ -528,21 +526,21 @@ class DeepseekV2MLAAttention(nn.Module):
     """
 
     def __init__(
-        self,
-        config: Union[DeepseekV2Config, DeepseekV3Config],
-        hidden_size: int,
-        num_heads: int,
-        qk_nope_head_dim: int,
-        qk_rope_head_dim: int,
-        v_head_dim: int,
-        q_lora_rank: Optional[int],
-        kv_lora_rank: int,
-        rope_theta: float = 10000,
-        rope_scaling: Optional[dict[str, Any]] = None,
-        max_position_embeddings: int = 8192,
-        cache_config: Optional[CacheConfig] = None,
-        quant_config: Optional[QuantizationConfig] = None,
-        prefix: str = "",
+            self,
+            config: Union[DeepseekV2Config, DeepseekV3Config],
+            hidden_size: int,
+            num_heads: int,
+            qk_nope_head_dim: int,
+            qk_rope_head_dim: int,
+            v_head_dim: int,
+            q_lora_rank: Optional[int],
+            kv_lora_rank: int,
+            rope_theta: float = 10000,
+            rope_scaling: Optional[dict[str, Any]] = None,
+            max_position_embeddings: int = 8192,
+            cache_config: Optional[CacheConfig] = None,
+            quant_config: Optional[QuantizationConfig] = None,
+            prefix: str = "",
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -559,7 +557,7 @@ class DeepseekV2MLAAttention(nn.Module):
         assert num_heads % tp_size == 0
         self.num_local_heads = num_heads // tp_size
 
-        self.scaling = self.qk_head_dim**-0.5
+        self.scaling = self.qk_head_dim ** -0.5
         self.rope_theta = rope_theta
         self.max_position_embeddings = max_position_embeddings
 
@@ -653,9 +651,9 @@ class DeepseekV2MLAAttention(nn.Module):
         )
 
     def forward(
-        self,
-        positions: torch.Tensor,
-        hidden_states: torch.Tensor,
+            self,
+            positions: torch.Tensor,
+            hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         return self.mla_attn(positions, hidden_states)
 
@@ -706,9 +704,9 @@ class DeepseekV2DecoderLayer(nn.Module):
             )
         if self.role is None or self.role == "ffn":
             if (
-                config.n_routed_experts is not None
-                and layer_idx >= config.first_k_dense_replace
-                and layer_idx % config.moe_layer_freq == 0
+                    config.n_routed_experts is not None
+                    and layer_idx >= config.first_k_dense_replace
+                    and layer_idx % config.moe_layer_freq == 0
             ):
                 self.mlp = DeepseekV2MoE(
                     config=config,
@@ -737,10 +735,10 @@ class DeepseekV2DecoderLayer(nn.Module):
             # 这里增加gating的初始化
             if layer_idx >= config.first_k_dense_replace:
                 self.gate = ReplicatedLinear(config.hidden_size,
-                                        config.n_routed_experts,
-                                        bias=False,
-                                        quant_config=None,
-                                        prefix=f"{prefix}.gate")
+                                             config.n_routed_experts,
+                                             bias=False,
+                                             quant_config=None,
+                                             prefix=f"{prefix}.gate")
                 if config.topk_method == "noaux_tc":
                     self.gate.e_score_correction_bias = nn.Parameter(
                         torch.empty(config.n_routed_experts, dtype=torch.float32))
@@ -762,11 +760,11 @@ class DeepseekV2DecoderLayer(nn.Module):
             self.n_redundant_experts = eplb_config.num_redundant_experts
             self.n_logical_experts = self.n_routed_experts
             self.n_physical_experts = (self.n_logical_experts +
-                                    self.n_redundant_experts)
+                                       self.n_redundant_experts)
             self.n_local_physical_experts = self.n_physical_experts // self.ep_size
 
             self.physical_expert_start = (self.ep_rank *
-                                        self.n_local_physical_experts)
+                                          self.n_local_physical_experts)
             self.physical_expert_end = (self.physical_expert_start +
                                         self.n_local_physical_experts)
         self.input_layernorm = RMSNorm(config.hidden_size,
@@ -776,10 +774,10 @@ class DeepseekV2DecoderLayer(nn.Module):
         self.routed_scaling_factor = config.routed_scaling_factor
 
     def forward(
-        self,
-        positions: torch.Tensor,
-        hidden_states: torch.Tensor,
-        residual: Optional[torch.Tensor],
+            self,
+            positions: torch.Tensor,
+            hidden_states: torch.Tensor,
+            residual: Optional[torch.Tensor],
     ) -> torch.Tensor:
         # Self Attention
         forward_ctx = get_forward_context()
@@ -787,7 +785,7 @@ class DeepseekV2DecoderLayer(nn.Module):
                         if forward_ctx is not None else None)
         afd_connector = (afd_metadata.afd_connector
                          if afd_metadata is not None else None)
-        
+
         if residual is None:
             residual = hidden_states.clone()
             hidden_states = self.input_layernorm(hidden_states)
@@ -824,13 +822,13 @@ class DeepseekV2DecoderLayer(nn.Module):
             hidden_states *= 1. / self.routed_scaling_factor
 
         return hidden_states, residual
-    
+
     def compute_attn_output(
-        self,
-        positions: torch.Tensor,
-        hidden_states: torch.Tensor,
-        residual: Optional[torch.Tensor],
-    ) -> torch.Tensor:        # Self Attention
+            self,
+            positions: torch.Tensor,
+            hidden_states: torch.Tensor,
+            residual: Optional[torch.Tensor],
+    ) -> torch.Tensor:  # Self Attention
         if residual is None:
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
@@ -855,25 +853,34 @@ class DeepseekV2DecoderLayer(nn.Module):
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(
             hidden_states, residual)
-        
+
         topk_weights = None
         topk_ids = None
         row_idx = None
         # Compute gate on attention side.
         if self.layer_idx >= self.first_k_dense_replace and self.afd_config.compute_gate_on_attention:
             router_logits, _ = self.gate(hidden_states)
-            topk_weights, topk_ids, row_idx = select_experts(
-                hidden_states=hidden_states,
-                router_logits=router_logits,
-                top_k=8,
-                use_grouped_topk=False,
-                renormalize=True,
-                e_score_correction_bias=self.gate.e_score_correction_bias,
+
+            forward_ctx = get_forward_context()
+            afd_connector = None
+            if forward_ctx and forward_ctx.afd_metadata and forward_ctx.afd_metadata.afd_connector:
+                afd_connector = forward_ctx.afd_metadata.afd_connector
+
+            if afd_connector:
+                topk_weights, topk_ids, row_idx = afd_connector.select_experts(
+                    hidden_states=hidden_states,
+                    router_logits=router_logits,
+                    top_k=8,
+                    use_grouped_topk=False,
+                    renormalize=True,
+                    e_score_correction_bias=self.gate.e_score_correction_bias,
                 )
-        
+            else:
+                raise RuntimeError("AFD connector required for compute_gate_on_attention but not found in context.")
+
             topk_weights = topk_weights.to(torch.float)
 
-        return hidden_states, residual, topk_weights, topk_ids, row_idx ,router_logits
+        return hidden_states, residual, topk_weights, topk_ids, row_idx, router_logits
 
     def compute_ffn_output(self,
                            hidden_states: torch.Tensor,
@@ -884,20 +891,20 @@ class DeepseekV2DecoderLayer(nn.Module):
                            topk_ids: Optional[torch.Tensor] = None,
                            row_idx: Optional[torch.Tensor] = None,
                            x_active_mask: Optional[torch.Tensor] = None,
-                           cam_p2p_ep_name: Optional[str] = "",):
+                           cam_p2p_ep_name: Optional[str] = "", ):
         assert self.role == "ffn"
         if self.afd_config is not None and self.afd_config.compute_gate_on_attention:
             hidden_states = self.mlp.afd_forward(
-                                    hidden_states = hidden_states, 
-                                    group_list = group_list,
-                                    dynamic_scales = dynamic_scales,
-                                    topk_weights=topk_weights,
-                                    topk_ids=topk_ids,
-                                    row_idx=row_idx if self.connector_name == "p2pconnector" else None,
-                                    router_logits=router_logits if self.connector_name == "p2pconnector" else None,
-                                    x_active_mask=x_active_mask if self.connector_name == "camp2pconnector" else None,
-                                    cam_p2p_ep_name=cam_p2p_ep_name if self.connector_name == "camp2pconnector" else "",
-                                    )
+                hidden_states=hidden_states,
+                group_list=group_list,
+                dynamic_scales=dynamic_scales,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                row_idx=row_idx,
+                router_logits=router_logits,
+                x_active_mask=x_active_mask,
+                cam_p2p_ep_name=cam_p2p_ep_name,
+            )
         else:
             hidden_states = self.mlp(hidden_states)
 
@@ -911,9 +918,9 @@ class DeepseekV2DecoderLayer(nn.Module):
             hidden_states *= 1. / self.routed_scaling_factor
         return hidden_states
 
+
 @support_torch_compile
 class DeepseekV2Model(nn.Module):
-
     fall_back_to_pt_during_load = False
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -974,96 +981,57 @@ class DeepseekV2Model(nn.Module):
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
-    
+
     def forward_m2n(
-        self,
-        hidden_states: torch.Tensor,
-        residual: torch.Tensor,
-        positions: torch.Tensor,
-        afd_metadata: AFDMetadata
-    )-> tuple[torch.Tensor, torch.Tensor]:
+            self,
+            hidden_states: torch.Tensor,
+            residual: torch.Tensor,
+            positions: torch.Tensor,
+            afd_metadata: AFDMetadata
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         recv_handle = None
-            
+
         forward_ctx = get_forward_context()
+        afd_connector = afd_metadata.afd_connector
         moe_comm_type = forward_ctx.moe_comm_type
         num_tokens = hidden_states.shape[0]
         with_prefill = forward_ctx.with_prefill
         num_actual_tokens = None
-        ffn_need_forward_data = FFNNeedForwardData(moe_comm_type,num_tokens,with_prefill,num_actual_tokens)
-        
+        ffn_need_forward_data = FFNNeedForwardData(moe_comm_type, num_tokens, with_prefill, num_actual_tokens)
+
         for layer in islice(self.layers, self.start_layer, self.end_layer):
             # Compute dense layers on attn side.
             if layer.layer_idx < self.first_k_dense_replace:
                 hidden_states, residual = layer(positions, hidden_states, residual)
                 # hidden_states = apply_dbo_yield(hidden_states)
                 continue
-            
-            afd_connector = afd_metadata.afd_connector
+
             afd_metadata.afd_stage_idx = forward_ctx.ubatch_idx
             start_idx = afd_metadata.afd_tokens_start_loc[afd_metadata.afd_stage_idx]
             end_idx = start_idx + afd_metadata.afd_tokens_lens[afd_metadata.afd_stage_idx]
 
             if self.enforce_eager:
-                logger.info(f"jcz deepseekv2 layer_idx:{layer.layer_idx} metadata:{afd_metadata} hidden_states:{hidden_states.shape}")
+                logger.info(
+                    f"jcz deepseekv2 layer_idx:{layer.layer_idx} metadata:{afd_metadata} hidden_states:{hidden_states.shape}")
                 logger.info(f"jcz deepseekv2 layer_idx:{layer.layer_idx} start_loc:{afd_metadata.afd_tokens_start_loc} "
                             f"start_idx:{start_idx} end_idx:{end_idx} "
                             f"stage_idx:{afd_metadata.afd_stage_idx}")
-            
+
             if recv_handle is not None:
                 for work in recv_handle:
                     work.wait()
 
             if layer.layer_idx > self.first_k_dense_replace:
-                if self.connector_name == "m2nconnector":
-                    recv_hidden_states = afd_connector.recv_ffn_output(ubatch_hidden_states[ubatch_idx],
-                                                                        ubatch_metadata[ubatch_idx],ubatch_idx)
-                    # recv_hidden_states = afd_connector.recv_ffn_output(ubatch_hidden_states[ubatch_idx],
-                    #                                                    ubatch_metadata[ubatch_idx],ubatch_idx)
-                elif self.connector_name == "camm2nconnector":
-                    recv_hidden_states = afd_connector.recv_ffn_output(hidden_states,
-                                                                        metadata,
-                                                                        forward_ctx.ubatch_idx)
-                    
-                else:
-                    recv_hidden_states, _ = afd_connector.recv_ffn_output()
-                    
+                # Pre-computation Receive Phase
+                # TODO:待适配M2N CAMP2P算子metadata
+                recv_hidden_states = afd_connector.recv_ffn_output(
+                    hidden_states=hidden_states,
+                    metadata=None,
+                )
                 hidden_states = recv_hidden_states
-            
-            current_hidden, residual, topk_weights, topk_ids, row_idx,router_logits= \
+
+            current_hidden, residual, topk_weights, topk_ids, row_idx, router_logits = \
                 layer.compute_attn_output(positions, hidden_states, residual)
-            if self.connector_name == "m2nconnector":
-                from vllm_ascend.distributed.M2NAFDConnector import M2NAFDConnectorMetadata
-                m2n_afdconnector_data = M2NAFDConnectorMetadata()
-                m2n_afdconnector_data.moe_expert_num = self.config.n_routed_experts
-                m2n_afdconnector_data.quant_mode = 0
-                m2n_afdconnector_data.aiv_num = 48
-                m2n_afdconnector_data.scale = None
-            if self.connector_name == "camm2nconnector":
-                from vllm_ascend.distributed.CAMM2NAFDConnector import CAMM2NAFDConnectorMetadata
-                cam_afdconnector_data = CAMM2NAFDConnectorMetadata(
-                    moe_expert_num = self.config.n_routed_experts,
-                    shared_expert_num = 0,
-                    scale = None,
-                    handle = None,
-                    quant_mode = 0,
-                    aiv_num = 48,
-                    batch_size = self.max_num_reqs,
-                    h = self.config.hidden_size,
-                    k = self.config.num_experts_per_tok
-                )
-            if self.connector_name == "camp2pconnector":
-                from vllm_ascend.distributed.CAMP2PAFDConnector import CAMP2PAFDConnectorMetadata
-                cam_afdconnector_data = CAMP2PAFDConnectorMetadata(
-                    moe_expert_num = self.config.n_routed_experts,
-                    shared_expert_num = 0,
-                    scale = None,
-                    handle = None,
-                    quant_mode = 0,
-                    aiv_num = 48,
-                    batch_size = self.max_num_reqs,
-                    h = self.config.hidden_size,
-                    k = self.config.num_experts_per_tok
-                )
 
             metadata = AFDConnectorMetadata.create_attention_metadata(
                 layer_idx=layer.layer_idx,
@@ -1073,52 +1041,40 @@ class DeepseekV2Model(nn.Module):
                 device=hidden_states.device,
                 num_ubatches=forward_ctx.num_ubatches,
                 ffn_need_forward_data=ffn_need_forward_data,
-                m2n_afdconnector_data=m2n_afdconnector_data if self.connector_name == "m2nconnector" else None,
-                cam_m2n_afdconnector_data=cam_afdconnector_data if self.connector_name == "camm2nconnector" else None,
-                cam_p2p_afdconnector_data=cam_afdconnector_data if self.connector_name == "camp2pconnector" else None,
+                connector_data=None,
+            )
+
+            afd_connector.configure_metadata(metadata, config=self.config, batch_size=self.max_num_reqs)
+
+            [hidden_states, send_attn_handle] = afd_connector.send_attn_output(
+                hidden_states=current_hidden,
+                metadata=metadata,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                router_logits=router_logits,
+                row_idx=row_idx
             )
             
-            if self.connector_name == "m2nconnector":
-                handle = afd_connector.send_attn_output(current_hidden,topk_weights,topk_ids,metadata)
-                metadata.m2n_afdconnector_data.handle = handle
-                hidden_states = afd_connector.recv_ffn_output(hidden_states,metadata)
-            elif self.connector_name == "camm2nconnector":
-                hidden_states = afd_connector.send_attn_output(current_hidden, topk_weights, topk_ids, metadata)
-            elif self.connector_name == "camp2pconnector":
-                output_list = afd_connector.send_attn_output(current_hidden, topk_weights, topk_ids, metadata)
-                hidden_states1, simulateExpertIds, simulateExpertScales, attenBatchSize, xActiveMaskOut = output_list[0:5]
-                handle = [hidden_states1, simulateExpertIds, simulateExpertScales, attenBatchSize]
-                metadata.cam_p2p_afdconnector_data.handle = handle
-            else:
-                afd_connector.send_attn_output(hidden_states = current_hidden,
-                                               router_logits = router_logits,
-                                               topk_weights = topk_weights, 
-                                               topk_ids = topk_ids, 
-                                               row_idx = row_idx, 
-                                               metadata = metadata)
-                hidden_states, _ = afd_connector.recv_ffn_output()
-                
+            if send_attn_handle is not None:
+                metadata.connector_data.handle = send_attn_handle
+
             hidden_states = apply_dbo_yield(hidden_states)
-            
-        if self.connector_name == "m2nconnector":
-                recv_hidden_states = afd_connector.recv_ffn_output(ubatch_hidden_states[ubatch_idx],
-                                                                   ubatch_metadata[ubatch_idx],ubatch_idx)
-        elif self.connector_name == "camm2nconnector":
-            recv_hidden_states = afd_connector.recv_ffn_output(hidden_states,
-                                                                metadata,
-                                                                forward_ctx.ubatch_idx)
-        else:
-            recv_hidden_states, _ = afd_connector.recv_ffn_output()
+
+        # TODO:待适配M2N CAMP2P算子metadata
+        recv_hidden_states = afd_connector.recv_ffn_output(
+            hidden_states=hidden_states,
+            metadata=afd_metadata
+        )
         hidden_states = recv_hidden_states
-        
+
         return hidden_states, residual
 
     def forward(
-        self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        intermediate_tensors: Optional[IntermediateTensors],
-        inputs_embeds: Optional[torch.Tensor] = None,
+            self,
+            input_ids: torch.Tensor,
+            positions: torch.Tensor,
+            intermediate_tensors: Optional[IntermediateTensors],
+            inputs_embeds: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, IntermediateTensors]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -1152,28 +1108,30 @@ class DeepseekV2Model(nn.Module):
         return hidden_states
 
     def compute_ffn_output(
-        self,
-        hidden_states,
-        layer_idx,
-        router_logits: Optional[torch.Tensor] = None,
-        group_list: Optional[torch.Tensor] = None,
-        dynamic_scales: Optional[torch.Tensor] = None,
-        topk_weights: Optional[torch.Tensor] = None,
-        topk_ids: Optional[torch.Tensor] = None,
-        row_idx: Optional[torch.Tensor] = None,
-        x_active_mask: Optional[torch.Tensor] = None,
-        cam_p2p_ep_name: Optional[str] = "",
+            self,
+            hidden_states,
+            layer_idx,
+            router_logits: Optional[torch.Tensor] = None,
+            group_list: Optional[torch.Tensor] = None,
+            dynamic_scales: Optional[torch.Tensor] = None,
+            topk_weights: Optional[torch.Tensor] = None,
+            topk_ids: Optional[torch.Tensor] = None,
+            row_idx: Optional[torch.Tensor] = None,
+            x_active_mask: Optional[torch.Tensor] = None,
+            cam_p2p_ep_name: Optional[str] = "",
     ) -> Union[torch.Tensor, IntermediateTensors]:
         if self.afd_config is not None and self.afd_config.compute_gate_on_attention:
-            hidden_states = self.layers[layer_idx].compute_ffn_output(hidden_states = hidden_states, 
-                                            group_list = group_list,
-                                            dynamic_scales = dynamic_scales,
-                                            topk_weights=topk_weights,
-                                            topk_ids=topk_ids,
-                                            row_idx=row_idx if self.connector_name == "p2pconnector" else None,
-                                            router_logits=router_logits if self.connector_name == "p2pconnector" else None,
-                                            x_active_mask=x_active_mask if self.connector_name == "camp2pconnector" else None,
-                                            cam_p2p_ep_name=cam_p2p_ep_name if self.connector_name == "camp2pconnector" else "",)
+            hidden_states = self.layers[layer_idx].compute_ffn_output(
+                hidden_states=hidden_states,
+                group_list=group_list,
+                dynamic_scales=dynamic_scales,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                row_idx=row_idx,
+                router_logits=router_logits,
+                x_active_mask=x_active_mask,
+                cam_p2p_ep_name=cam_p2p_ep_name,
+            )
         else:
             hidden_states = self.layers[layer_idx].compute_ffn_output(hidden_states)
         return hidden_states
@@ -1234,7 +1192,7 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts,
 
             assert isinstance(layer, DeepseekV2DecoderLayer)
             if (self.afd_role is None or self.afd_role == "ffn") and \
-                isinstance(layer.mlp, DeepseekV2MoE):
+                    isinstance(layer.mlp, DeepseekV2MoE):
                 # Pick last one layer since the first ones may be dense layers.
                 example_moe = layer.mlp
                 self.moe_layers.append(layer.mlp.experts)
@@ -1252,10 +1210,10 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts,
         self.num_redundant_experts = example_moe.n_redundant_experts
 
     def set_eplb_state(
-        self,
-        expert_load_view: torch.Tensor,
-        logical_to_physical_map: torch.Tensor,
-        logical_replica_count: torch.Tensor,
+            self,
+            expert_load_view: torch.Tensor,
+            logical_to_physical_map: torch.Tensor,
+            logical_replica_count: torch.Tensor,
     ) -> None:
         for layer_idx, layer in enumerate(self.moe_layers):
             # Register the expert weights.
@@ -1268,9 +1226,9 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts,
             )
 
     def update_physical_experts_metadata(
-        self,
-        num_physical_experts: int,
-        num_local_physical_experts: int,
+            self,
+            num_physical_experts: int,
+            num_local_physical_experts: int,
     ) -> None:
         assert self.num_local_physical_experts == num_local_physical_experts
         self.num_physical_experts = num_physical_experts
@@ -1289,46 +1247,46 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts,
         return self.model.get_input_embeddings(input_ids)
 
     def forward(
-        self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        intermediate_tensors: Optional[IntermediateTensors] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
+            self,
+            input_ids: torch.Tensor,
+            positions: torch.Tensor,
+            intermediate_tensors: Optional[IntermediateTensors] = None,
+            inputs_embeds: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, IntermediateTensors]:
         hidden_states = self.model(input_ids, positions, intermediate_tensors,
                                    inputs_embeds)
         return hidden_states
 
     def compute_ffn_output(
-        self,
-        hidden_states: torch.Tensor,
-        layer_idx: int,
-        router_logits: Optional[torch.Tensor] = None,
-        group_list: Optional[torch.Tensor] = None,
-        dynamic_scales: Optional[torch.Tensor] = None,
-        topk_weights: Optional[torch.Tensor] = None,
-        topk_ids: Optional[torch.Tensor] = None,
-        row_idx: Optional[torch.Tensor] = None,
-        x_active_mask: Optional[torch.Tensor] = None,
-        cam_p2p_ep_name: Optional[str] = "",
+            self,
+            hidden_states: torch.Tensor,
+            layer_idx: int,
+            router_logits: Optional[torch.Tensor] = None,
+            group_list: Optional[torch.Tensor] = None,
+            dynamic_scales: Optional[torch.Tensor] = None,
+            topk_weights: Optional[torch.Tensor] = None,
+            topk_ids: Optional[torch.Tensor] = None,
+            row_idx: Optional[torch.Tensor] = None,
+            x_active_mask: Optional[torch.Tensor] = None,
+            cam_p2p_ep_name: Optional[str] = "",
     ) -> Union[torch.Tensor, IntermediateTensors]:
         hidden_states = self.model.compute_ffn_output(
-                                    hidden_states=hidden_states,
-                                    layer_idx=layer_idx, 
-                                    group_list=group_list,
-                                    topk_weights=topk_weights,
-                                    topk_ids=topk_ids,
-                                    dynamic_scales=dynamic_scales,
-                                    row_idx=row_idx if self.connector_name == "p2pconnector" else None,
-                                    router_logits=router_logits if self.connector_name == "p2pconnector" else None,
-                                    x_active_mask=x_active_mask if self.connector_name == "camp2pconnector" else None,
-                                    cam_p2p_ep_name=cam_p2p_ep_name if self.connector_name == "camp2pconnector" else "",
-                                    )
+            hidden_states=hidden_states,
+            layer_idx=layer_idx,
+            router_logits=router_logits,
+            group_list=group_list,
+            dynamic_scales=dynamic_scales,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            row_idx=row_idx,
+            x_active_mask=x_active_mask,
+            cam_p2p_ep_name=cam_p2p_ep_name,
+        )
         return hidden_states
 
     def compute_logits(
-        self,
-        hidden_states: torch.Tensor,
+            self,
+            hidden_states: torch.Tensor,
     ) -> Optional[torch.Tensor]:
         logits = self.logits_processor(self.lm_head, hidden_states)
         return logits
@@ -1363,7 +1321,7 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts,
             if "rotary_emb.inv_freq" in name:
                 continue
             if self.afd_role == "attention" and \
-                self.is_moe_weight(name):
+                    self.is_moe_weight(name):
                 continue
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
             if spec_layer is not None:
@@ -1413,7 +1371,7 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts,
                     # attempted to load as other weights later
                     is_expert_weight = True
                     if self.afd_role is not None and \
-                        self.afd_role == "attention":
+                            self.afd_role == "attention":
                         continue
                     # Do not modify `name` since the loop may continue here
                     # Instead, create a new variable
@@ -1469,16 +1427,17 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts,
 
     def is_moe_weight(self, name):
         if "shared_experts" in name or "experts" in name or "gate" in name \
-            or "up" in name or "down" in name:
+                or "up" in name or "down" in name:
             return True
         return False
 
     def is_common_weight(self, name):
         if "lm_head" in name or "model.norm.weight" in name or "embed_tokens" in name \
-            or "input_layernorm" in name or "post_attention_layernorm" in name:
+                or "input_layernorm" in name or "post_attention_layernorm" in name:
             # or "model.layers.0.self_attn.o_proj.weight" in name:# for init kv cache
             return True
         return False
+
 
 class DeepseekV3ForCausalLM(DeepseekV2ForCausalLM):
     pass
@@ -1493,9 +1452,10 @@ def get_spec_layer_idx_from_weight_name(config: Union[DeepseekV2Config,
             and config.num_nextn_predict_layers > 0):
         layer_idx = config.num_hidden_layers
         for i in range(config.num_nextn_predict_layers):
-            if weight_name.startswith(f"model.layers.{layer_idx+i}."):
+            if weight_name.startswith(f"model.layers.{layer_idx + i}."):
                 return layer_idx + i
     return None
+
 
 from vllm.utils import direct_register_custom_op
 
@@ -1505,6 +1465,7 @@ def manual_dbo_yield_op(x: torch.Tensor) -> torch.Tensor:
         dbo_yield()
     return x
 
+
 def manual_dbo_yield_fake(x: torch.Tensor) -> torch.Tensor:
     return x
 
@@ -1513,8 +1474,9 @@ direct_register_custom_op(
     op_name="manual_dbo_yield",
     op_func=manual_dbo_yield_op,
     fake_impl=manual_dbo_yield_fake,
-    mutates_args=[] 
+    mutates_args=[]
 )
+
 
 def apply_dbo_yield(x: torch.Tensor) -> torch.Tensor:
     return torch.ops.vllm.manual_dbo_yield(x)

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -526,21 +526,21 @@ class DeepseekV2MLAAttention(nn.Module):
     """
 
     def __init__(
-            self,
-            config: Union[DeepseekV2Config, DeepseekV3Config],
-            hidden_size: int,
-            num_heads: int,
-            qk_nope_head_dim: int,
-            qk_rope_head_dim: int,
-            v_head_dim: int,
-            q_lora_rank: Optional[int],
-            kv_lora_rank: int,
-            rope_theta: float = 10000,
-            rope_scaling: Optional[dict[str, Any]] = None,
-            max_position_embeddings: int = 8192,
-            cache_config: Optional[CacheConfig] = None,
-            quant_config: Optional[QuantizationConfig] = None,
-            prefix: str = "",
+        self,
+        config: Union[DeepseekV2Config, DeepseekV3Config],
+        hidden_size: int,
+        num_heads: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+        q_lora_rank: Optional[int],
+        kv_lora_rank: int,
+        rope_theta: float = 10000,
+        rope_scaling: Optional[dict[str, Any]] = None,
+        max_position_embeddings: int = 8192,
+        cache_config: Optional[CacheConfig] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -673,6 +673,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         self.role = self.afd_config.afd_role if self.afd_config is not None else None
         self.connector_name = self.afd_config.afd_connector if self.afd_config is not None else None
         self.hidden_size = config.hidden_size
+        self.top_k = getattr(config, 'num_experts_per_tok', 8)
         rope_theta = getattr(config, "rope_theta", 10000)
         rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings",
@@ -774,10 +775,10 @@ class DeepseekV2DecoderLayer(nn.Module):
         self.routed_scaling_factor = config.routed_scaling_factor
 
     def forward(
-            self,
-            positions: torch.Tensor,
-            hidden_states: torch.Tensor,
-            residual: Optional[torch.Tensor],
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: Optional[torch.Tensor],
     ) -> torch.Tensor:
         # Self Attention
         forward_ctx = get_forward_context()
@@ -870,7 +871,7 @@ class DeepseekV2DecoderLayer(nn.Module):
                 topk_weights, topk_ids, row_idx = afd_connector.select_experts(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
-                    top_k=8,
+                    top_k=self.top_k,
                     use_grouped_topk=False,
                     renormalize=True,
                     e_score_correction_bias=self.gate.e_score_correction_bias,
@@ -936,6 +937,7 @@ class DeepseekV2Model(nn.Module):
         self.config = config
         self.enforce_eager = vllm_config.model_config.enforce_eager
         self.first_k_dense_replace = config.first_k_dense_replace
+        self.top_k = getattr(config, 'num_experts_per_tok', 8)
         self.afd_config = vllm_config.afd_config
         self.connector_name = self.afd_config.afd_connector if self.afd_config is not None else None
 
@@ -1101,30 +1103,30 @@ class DeepseekV2Model(nn.Module):
         return hidden_states
 
     def compute_ffn_output(
-            self,
-            hidden_states,
-            layer_idx,
-            router_logits: Optional[torch.Tensor] = None,
-            group_list: Optional[torch.Tensor] = None,
-            dynamic_scales: Optional[torch.Tensor] = None,
-            topk_weights: Optional[torch.Tensor] = None,
-            topk_ids: Optional[torch.Tensor] = None,
-            row_idx: Optional[torch.Tensor] = None,
-            x_active_mask: Optional[torch.Tensor] = None,
-            cam_p2p_ep_name: Optional[str] = "",
+        self,
+        hidden_states,
+        layer_idx,
+        router_logits: Optional[torch.Tensor] = None,
+        group_list: Optional[torch.Tensor] = None,
+        dynamic_scales: Optional[torch.Tensor] = None,
+        topk_weights: Optional[torch.Tensor] = None,
+        topk_ids: Optional[torch.Tensor] = None,
+        row_idx: Optional[torch.Tensor] = None,
+        x_active_mask: Optional[torch.Tensor] = None,
+        cam_p2p_ep_name: Optional[str] = "",
     ) -> Union[torch.Tensor, IntermediateTensors]:
         if self.afd_config is not None and self.afd_config.compute_gate_on_attention:
             hidden_states = self.layers[layer_idx].compute_ffn_output(
-                hidden_states=hidden_states,
-                group_list=group_list,
-                dynamic_scales=dynamic_scales,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-                row_idx=row_idx,
-                router_logits=router_logits,
-                x_active_mask=x_active_mask,
-                cam_p2p_ep_name=cam_p2p_ep_name,
-            )
+                                                    hidden_states=hidden_states,
+                                                    group_list=group_list,
+                                                    dynamic_scales=dynamic_scales,
+                                                    topk_weights=topk_weights,
+                                                    topk_ids=topk_ids,
+                                                    row_idx=row_idx,
+                                                    router_logits=router_logits,
+                                                    x_active_mask=x_active_mask,
+                                                    cam_p2p_ep_name=cam_p2p_ep_name,
+                                                    )
         else:
             hidden_states = self.layers[layer_idx].compute_ffn_output(hidden_states)
         return hidden_states
@@ -1264,22 +1266,22 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts,
             cam_p2p_ep_name: Optional[str] = "",
     ) -> Union[torch.Tensor, IntermediateTensors]:
         hidden_states = self.model.compute_ffn_output(
-            hidden_states=hidden_states,
-            layer_idx=layer_idx,
-            router_logits=router_logits,
-            group_list=group_list,
-            dynamic_scales=dynamic_scales,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            row_idx=row_idx,
-            x_active_mask=x_active_mask,
-            cam_p2p_ep_name=cam_p2p_ep_name,
-        )
+                                    hidden_states=hidden_states,
+                                    layer_idx=layer_idx,
+                                    router_logits=router_logits,
+                                    group_list=group_list,
+                                    dynamic_scales=dynamic_scales,
+                                    topk_weights=topk_weights,
+                                    topk_ids=topk_ids,
+                                    row_idx=row_idx,
+                                    x_active_mask=x_active_mask,
+                                    cam_p2p_ep_name=cam_p2p_ep_name,
+                                    )
         return hidden_states
 
     def compute_logits(
-            self,
-            hidden_states: torch.Tensor,
+        self,
+        hidden_states: torch.Tensor,
     ) -> Optional[torch.Tensor]:
         logits = self.logits_processor(self.lm_head, hidden_states)
         return logits

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -40,7 +40,7 @@ from vllm.distributed import (get_ep_group, get_pp_group, set_substitute_tp,
                               get_tensor_model_parallel_world_size,
                               tensor_model_parallel_all_gather)
 from vllm.distributed.afd_transfer.afd_connector.metadata import (
-    AFDConnectorMetadata, FFNNeedForwardData)
+    AFDConnectorMetadata)
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -993,12 +993,6 @@ class DeepseekV2Model(nn.Module):
 
         forward_ctx = get_forward_context()
         afd_connector = afd_metadata.afd_connector
-        moe_comm_type = forward_ctx.moe_comm_type
-        num_tokens = hidden_states.shape[0]
-        with_prefill = forward_ctx.with_prefill
-        num_actual_tokens = None
-        ffn_need_forward_data = FFNNeedForwardData(moe_comm_type, num_tokens, with_prefill, num_actual_tokens)
-
         for layer in islice(self.layers, self.start_layer, self.end_layer):
             # Compute dense layers on attn side.
             if layer.layer_idx < self.first_k_dense_replace:
@@ -1040,7 +1034,6 @@ class DeepseekV2Model(nn.Module):
                 dtype=hidden_states.dtype,
                 device=hidden_states.device,
                 num_ubatches=forward_ctx.num_ubatches,
-                ffn_need_forward_data=ffn_need_forward_data,
                 connector_data=None,
             )
 

--- a/vllm/v1/worker/ubatching.py
+++ b/vllm/v1/worker/ubatching.py
@@ -10,7 +10,9 @@ from vllm.forward_context import ForwardContext
 from vllm.utils import current_stream
 
 _THREAD_ID_TO_CONTEXT: dict = {}
-_CURRENT_CONTEXTS: list[Optional['UBatchContext']] = [None, None]
+# here we hardcode the number of micro-batches to 2
+_NUM_UBATCHES: int = 2
+_CURRENT_CONTEXTS: list[Optional['UBatchContext']] = []
 
 
 class UBatchContext:
@@ -180,7 +182,7 @@ dbo_switch_to_compute_sync = _register_ubatch_function(
 def dbo_register_recv_hook(recv_hook):
     if len(_THREAD_ID_TO_CONTEXT) > 0:
         ctx_idx = _THREAD_ID_TO_CONTEXT[threading.get_ident()]
-        next_ctx = _CURRENT_CONTEXTS[(ctx_idx + 1) % 2]
+        next_ctx = _CURRENT_CONTEXTS[(ctx_idx + 1) % _NUM_UBATCHES]
         next_ctx.recv_hook = recv_hook
 
 
@@ -192,10 +194,19 @@ def make_ubatch_contexts(
     ready_barrier: threading.Barrier,
     schedule: str = "default",
 ) -> list[UBatchContext]:
-    assert num_micro_batches == 2, "only been tested with 2 micro-batches"
     """
-    Create a context manager for micro-batching synchronization.
+        Create a context manager for micro-batching synchronization.
     """
+
+    global _NUM_UBATCHES, _CURRENT_CONTEXTS
+    assert num_micro_batches > 1, "num_micro_batches must be greater than 1"
+
+    _NUM_UBATCHES = num_micro_batches
+
+    # Ensure the global context list is large enough
+    if len(_CURRENT_CONTEXTS) < num_micro_batches:
+        _CURRENT_CONTEXTS.extend([None] * (num_micro_batches - len(_CURRENT_CONTEXTS)))
+
     cpu_events = [threading.Event() for _ in range(num_micro_batches)]
     gpu_comm_done_events = [
         torch.cuda.Event() for _ in range(num_micro_batches)
@@ -204,7 +215,7 @@ def make_ubatch_contexts(
         torch.cuda.Event() for _ in range(num_micro_batches)
     ]
 
-    assert len(forward_contexts) == 2
+    assert len(forward_contexts) == num_micro_batches
 
     ctxs = []
     for i in range(num_micro_batches):


### PR DESCRIPTION
### What this PR does / why we need it?

Refactor the code, remove redundant code, and decouple the vllm's reverse dependency on vllm_ascend.

1. Unified AFDConnectorMetadata
2. Decoupling AFDConnectorMetadata configuration
3. MoE computation call logic sinking: MoE computation call logic is sinked to the AFDConnector interface, avoiding the need for numerous `if Connector_name == ...` branching code in the model layer.
4. Unified AFDConnector interface: Unified interfaces such as `send_attn_output`, `recv_ffn_output`, `send_ffn_output`, and `recv_attn_output` for different AFDConnectors, using `**kwargs` to pass differentiated parameters.
5. Decoupling ConnectorFactory registration: Based on the `vllm_ascend` plugin mechanism `entry_points`, automatically discovers and loads `vllm_ascend`-related AFDConnectors when starting vllm, eliminating the need for hard-coded coupling.
6. Refactoring Ubatch, decoupling and reusing existing vllm code.


### Does this PR introduce _any_ user-facing change?
noting changed·

### How was this patch tested?

CI passed with new added/existing test.
