### PR TITLE
afd support enable force load_balance

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1434,6 +1434,27 @@ class DeepseekV2DecoderLayer(nn.Module):
                     num_shared_experts=self.config.n_shared_experts,
                     global_num_experts=global_num_experts
                 )
+                enable_force_load_balance = self.vllm_config.additional_config.get("enable_force_load_balance", False)
+                global_num_experts = self.config.n_routed_experts
+                if enable_force_load_balance:
+                    # Construct a basic expert ID sequence and perform block-level cyclic shifting
+                    base = torch.arange(global_num_experts, dtype=torch.int32, device=topk_ids.device)
+                    # Assume it is divisible; otherwise, additional processing is required.
+                    block_size = global_num_experts // self.ep_size
+                    base_blocks = base.reshape(self.ep_size, block_size)
+                    shifted_blocks = torch.cat([base_blocks[self.ep_rank:], base_blocks[:self.ep_rank]], dim=0)
+                    base_shifted = shifted_blocks.reshape(-1)
+
+                    total_needed = topk_ids.shape[0] * self.top_k
+                    repeat_times = (total_needed + global_num_experts - 1) // global_num_experts
+                    expanded = base_shifted.repeat(repeat_times)[:total_needed]
+                    fake_routed_topk_ids = expanded.reshape(topk_ids.shape[0], self.top_k)
+
+                    if mix_placement:
+                        shared_topk_ids = topk_ids[:, self.top_k:]
+                        topk_ids = torch.cat([fake_routed_topk_ids, shared_topk_ids], dim=1)
+                    else:
+                        topk_ids = fake_routed_topk_ids
             else:
                 raise RuntimeError("AFD connector required for compute_gate_on_attention but not found in context.")
 


### PR DESCRIPTION
When forced load balancing needs to be enabled, add the following startup parameters: 
--additional-config '{"enable_force_load_balance": "True"}'

case1: dsv2: camp2p 开启强制负载均衡，topk_ids:
(EngineCore_DP0 pid=102005) ttg compute_attn_output topk_ids: tensor([[ 0,  1,  2,  3,  4,  5,  6,  7],
(EngineCore_DP0 pid=102005)         [ 8,  9, 10, 11, 12, 13, 14, 15],
(EngineCore_DP0 pid=102005)         [16, 17, 18, 19, 20, 21, 22, 23],
(EngineCore_DP0 pid=102005)         [24, 25, 26, 27, 28, 29, 30, 31],
(EngineCore_DP0 pid=102005)         [32, 33, 34, 35, 36, 37, 38, 39],
(EngineCore_DP0 pid=102005)         [40, 41, 42, 43, 44, 45, 46, 47],
(EngineCore_DP0 pid=102005)         [48, 49, 50, 51, 52, 53, 54, 55],
(EngineCore_DP0 pid=102005)         [56, 57, 58, 59, 60, 61, 62, 63],
(EngineCore_DP0 pid=102005)         [ 0,  1,  2,  3,  4,  5,  6,  7],
(EngineCore_DP0 pid=102005)         [ 8,  9, 10, 11, 12, 13, 14, 15],
(EngineCore_DP0 pid=102005)         [16, 17, 18, 19, 20, 21, 22, 23],
(EngineCore_DP0 pid=102005)         [24, 25, 26, 27, 28, 29, 30, 31],
(EngineCore_DP0 pid=102005)         [32, 33, 34, 35, 36, 37, 38, 39],
(EngineCore_DP0 pid=102005)         [40, 41, 42, 43, 44, 45, 46, 47],
(EngineCore_DP0 pid=102005)         [48, 49, 50, 51, 52, 53, 54, 55],
(EngineCore_DP0 pid=102005)         [56, 57, 58, 59, 60, 61, 62, 63],
(EngineCore_DP0 pid=102005)         [ 0,  1,  2,  3,  4,  5,  6,  7],
(EngineCore_DP0 pid=102005)         [ 8,  9, 10, 11, 12, 13, 14, 15],
(EngineCore_DP0 pid=102005)         [16, 17, 18, 19, 20, 21, 22, 23],
(EngineCore_DP0 pid=102005)         [24, 25, 26, 27, 28, 29, 30, 31]], device='npu:0', dtype=torch.int32)
(EngineCore_DP1 pid=102006) ttg compute_attn_output topk_ids: tensor([[32, 33, 34, 35, 36, 37, 38, 39],
(EngineCore_DP1 pid=102006)         [40, 41, 42, 43, 44, 45, 46, 47],
(EngineCore_DP1 pid=102006)         [48, 49, 50, 51, 52, 53, 54, 55],
(EngineCore_DP1 pid=102006)         [56, 57, 58, 59, 60, 61, 62, 63],
(EngineCore_DP1 pid=102006)         [ 0,  1,  2,  3,  4,  5,  6,  7],
(EngineCore_DP1 pid=102006)         [ 8,  9, 10, 11, 12, 13, 14, 15],
(EngineCore_DP1 pid=102006)         [16, 17, 18, 19, 20, 21, 22, 23],
(EngineCore_DP1 pid=102006)         [24, 25, 26, 27, 28, 29, 30, 31],
(EngineCore_DP1 pid=102006)         [32, 33, 34, 35, 36, 37, 38, 39],
(EngineCore_DP1 pid=102006)         [40, 41, 42, 43, 44, 45, 46, 47],
(EngineCore_DP1 pid=102006)         [48, 49, 50, 51, 52, 53, 54, 55],
(EngineCore_DP1 pid=102006)         [56, 57, 58, 59, 60, 61, 62, 63],
(EngineCore_DP1 pid=102006)         [ 0,  1,  2,  3,  4,  5,  6,  7],
(EngineCore_DP1 pid=102006)         [ 8,  9, 10, 11, 12, 13, 14, 15],
(EngineCore_DP1 pid=102006)         [16, 17, 18, 19, 20, 21, 22, 23],
(EngineCore_DP1 pid=102006)         [24, 25, 26, 27, 28, 29, 30, 31],
(EngineCore_DP1 pid=102006)         [32, 33, 34, 35, 36, 37, 38, 39],
(EngineCore_DP1 pid=102006)         [40, 41, 42, 43, 44, 45, 46, 47],
(EngineCore_DP1 pid=102006)         [48, 49, 50, 51, 52, 53, 54, 55],
(EngineCore_DP1 pid=102006)         [56, 57, 58, 59, 60, 61, 62, 63]], device='npu:0', dtype=torch.int32)

case2:dsv2 camp2p + 强制负载均衡 + top9(只对路由专家进行强制负载均衡)：
(EngineCore_DP0 pid=103844) ttg compute_attn_output topk_ids: tensor([[ 0,  1,  2,  3,  4,  5,  6,  7, 64, 65],
(EngineCore_DP0 pid=103844)         [ 8,  9, 10, 11, 12, 13, 14, 15, 64, 65],
(EngineCore_DP0 pid=103844)         [16, 17, 18, 19, 20, 21, 22, 23, 64, 65],
(EngineCore_DP0 pid=103844)         [24, 25, 26, 27, 28, 29, 30, 31, 64, 65],
(EngineCore_DP0 pid=103844)         [32, 33, 34, 35, 36, 37, 38, 39, 64, 65],
(EngineCore_DP0 pid=103844)         [40, 41, 42, 43, 44, 45, 46, 47, 64, 65],
(EngineCore_DP0 pid=103844)         [48, 49, 50, 51, 52, 53, 54, 55, 64, 65],
(EngineCore_DP0 pid=103844)         [56, 57, 58, 59, 60, 61, 62, 63, 64, 65],
(EngineCore_DP0 pid=103844)         [ 0,  1,  2,  3,  4,  5,  6,  7, 64, 65],
(EngineCore_DP0 pid=103844)         [ 8,  9, 10, 11, 12, 13, 14, 15, 64, 65],
(EngineCore_DP0 pid=103844)         [16, 17, 18, 19, 20, 21, 22, 23, 64, 65],
(EngineCore_DP0 pid=103844)         [24, 25, 26, 27, 28, 29, 30, 31, 64, 65],
(EngineCore_DP0 pid=103844)         [32, 33, 34, 35, 36, 37, 38, 39, 64, 65],
(EngineCore_DP0 pid=103844)         [40, 41, 42, 43, 44, 45, 46, 47, 64, 65],
(EngineCore_DP0 pid=103844)         [48, 49, 50, 51, 52, 53, 54, 55, 64, 65],
(EngineCore_DP0 pid=103844)         [56, 57, 58, 59, 60, 61, 62, 63, 64, 65],
(EngineCore_DP0 pid=103844)         [ 0,  1,  2,  3,  4,  5,  6,  7, 64, 65],
(EngineCore_DP0 pid=103844)         [ 8,  9, 10, 11, 12, 13, 14, 15, 64, 65],
(EngineCore_DP0 pid=103844)         [16, 17, 18, 19, 20, 21, 22, 23, 64, 65],
(EngineCore_DP0 pid=103844)         [24, 25, 26, 27, 28, 29, 30, 31, 64, 65]], device='npu:0',
(EngineCore_DP0 pid=103844)        dtype=torch.int32)
(EngineCore_DP1 pid=103845) INFO 03-11 14:48:55 [deepseek_v2.py:1603] forward_m2n deepseek_v2 layer_idx:26 start_loc:[0] stage_idx:0, hidde
n_states:torch.Size([20, 2048])
(EngineCore_DP0 pid=103844) INFO 03-11 14:48:55 [deepseek_v2.py:1603] forward_m2n deepseek_v2 layer_idx:26 start_loc:[0] stage_idx:0, hidde
n_states:torch.Size([20, 2048])
(EngineCore_DP1 pid=103845) ttg compute_attn_output topk_ids: tensor([[32, 33, 34, 35, 36, 37, 38, 39, 64, 65],
(EngineCore_DP1 pid=103845)         [40, 41, 42, 43, 44, 45, 46, 47, 64, 65],
(EngineCore_DP1 pid=103845)         [48, 49, 50, 51, 52, 53, 54, 55, 64, 65],
(EngineCore_DP1 pid=103845)         [56, 57, 58, 59, 60, 61, 62, 63, 64, 65],
(EngineCore_DP1 pid=103845)         [ 0,  1,  2,  3,  4,  5,  6,  7, 64, 65],
(EngineCore_DP1 pid=103845)         [ 8,  9, 10, 11, 12, 13, 14, 15, 64, 65],
(EngineCore_DP1 pid=103845)         [16, 17, 18, 19, 20, 21, 22, 23, 64, 65],
(EngineCore_DP1 pid=103845)         [24, 25, 26, 27, 28, 29, 30, 31, 64, 65],
(EngineCore_DP1 pid=103845)         [32, 33, 34, 35, 36, 37, 38, 39, 64, 65],
(EngineCore_DP1 pid=103845)         [40, 41, 42, 43, 44, 45, 46, 47, 64, 65],
(EngineCore_DP1 pid=103845)         [48, 49, 50, 51, 52, 53, 54, 55, 64, 65],
(EngineCore_DP1 pid=103845)         [56, 57, 58, 59, 60, 61, 62, 63, 64, 65],
(EngineCore_DP1 pid=103845)         [ 0,  1,  2,  3,  4,  5,  6,  7, 64, 65],
(EngineCore_DP1 pid=103845)         [ 8,  9, 10, 11, 12, 13, 14, 15, 64, 65],
(EngineCore_DP1 pid=103845)         [16, 17, 18, 19, 20, 21, 22, 23, 64, 65],
(EngineCore_DP1 pid=103845)         [24, 25, 26, 27, 28, 29, 30, 31, 64, 65],
(EngineCore_DP1 pid=103845)         [32, 33, 34, 35, 36, 37, 38, 39, 64, 65],
(EngineCore_DP1 pid=103845)         [40, 41, 42, 43, 44, 45, 46, 47, 64, 65],
(EngineCore_DP1 pid=103845)         [48, 49, 50, 51, 52, 53, 54, 55, 64, 65],
(EngineCore_DP1 pid=103845)         [56, 57, 58, 59, 60, 61, 62, 63, 64, 65]], device='npu:0',
(EngineCore_DP1 pid=103845)        dtype=torch.int32)

